### PR TITLE
feat: 표(ListObject) 엔진 + 가상 분석 도구 구현 (Phase 5-1, 5-2)

### DIFF
--- a/packages/frontend/src/components/GridCanvas.tsx
+++ b/packages/frontend/src/components/GridCanvas.tsx
@@ -8,6 +8,7 @@ import { HistoryManager, ClipboardManager } from '../core/history'
 import { GridRenderer } from '../core/renderer'
 import { filterManager } from '../core/data'
 import type { FilterCriteria } from '../core/data'
+import { tableManager } from '../core/table'
 import { FilterDropdown } from './FilterDropdown'
 import { useWorkbookStore } from '../store/useWorkbookStore'
 import { useUIStore } from '../store/useUIStore'
@@ -90,6 +91,14 @@ export function GridCanvas() {
                     formula: isFormula ? value : undefined,
                 }
                 s.setCell(s.activeSheetId, row, col, cellData)
+
+                // 표 자동 확장 감지
+                const tableId = tableManager.checkAutoExpand(s.activeSheetId, row, col, getCell)
+                if (tableId) {
+                    tableManager.expandTable(tableId, (r, c, data) =>
+                        s.setCell(s.activeSheetId, r, c, data ?? { value: null }),
+                    )
+                }
             }
 
             // ── 캔버스 초기 크기 설정 ────────────────────────────────────────────
@@ -102,6 +111,26 @@ export function GridCanvas() {
             const viewport = new ViewportManager(initW, initH)
             const selection = new SelectionManager(useWorkbookStore.getState().activeSheetId)
             const input = new InputManager(canvas, container, viewport, selection, onCommit)
+            input.setCreateTableCallback(() => {
+                const s = useWorkbookStore.getState()
+                const selState = selection.getState()
+                const { selections, activeCell } = selState
+                let r1: number, c1: number, r2: number, c2: number
+                if (selections.length > 0) {
+                    const sel = selections[0]
+                    r1 = Math.min(sel.start.row, sel.end.row)
+                    c1 = Math.min(sel.start.col, sel.end.col)
+                    r2 = Math.max(sel.start.row, sel.end.row)
+                    c2 = Math.max(sel.start.col, sel.end.col)
+                } else if (activeCell) {
+                    r1 = r2 = activeCell.row
+                    c1 = c2 = activeCell.col
+                } else {
+                    return
+                }
+                tableManager.createTable(s.activeSheetId, r1, c1, r2, c2, getCell)
+                    .catch((err) => console.error('[TableManager] createTable failed:', err))
+            })
             const history = new HistoryManager()
             const clipboard = new ClipboardManager(selection, history, getCell, setCell)
             const selectionRenderer = new SelectionRenderer(viewport)

--- a/packages/frontend/src/components/dialogs/DataTableDialog.tsx
+++ b/packages/frontend/src/components/dialogs/DataTableDialog.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react'
+import { dataTableSolver } from '../../core/analysis'
+import type { DataTableParams } from '../../core/analysis'
+import type { CellData } from '@cellix/shared'
+
+interface Props {
+    sheetId: string
+    setCell: (row: number, col: number, data: CellData) => void
+    onClose: () => void
+}
+
+function parseCellRef(ref: string): { row: number; col: number } | null {
+    const m = ref.trim().toUpperCase().match(/^([A-Z]+)(\d+)$/)
+    if (!m) return null
+    let col = 0
+    for (const ch of m[1]) col = col * 26 + (ch.charCodeAt(0) - 64)
+    return { row: parseInt(m[2], 10) - 1, col: col - 1 }
+}
+
+function parseRangeRef(ref: string): {
+    startRow: number; startCol: number; endRow: number; endCol: number
+} | null {
+    const parts = ref.trim().toUpperCase().split(':')
+    if (parts.length !== 2) return null
+    const a = parseCellRef(parts[0])
+    const b = parseCellRef(parts[1])
+    if (!a || !b) return null
+    return {
+        startRow: Math.min(a.row, b.row),
+        startCol: Math.min(a.col, b.col),
+        endRow: Math.max(a.row, b.row),
+        endCol: Math.max(a.col, b.col),
+    }
+}
+
+export function DataTableDialog({ sheetId, setCell, onClose }: Props) {
+    const [resultRef, setResultRef] = useState('')
+    const [tableRangeRef, setTableRangeRef] = useState('')
+    const [rowInputRef, setRowInputRef] = useState('')
+    const [colInputRef, setColInputRef] = useState('')
+    const [running, setRunning] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [done, setDone] = useState(false)
+
+    const handleSolve = async () => {
+        setError(null)
+        setDone(false)
+
+        const resultCell = parseCellRef(resultRef)
+        if (!resultCell) { setError('결과 수식 셀 주소가 올바르지 않습니다.'); return }
+
+        const tableRange = parseRangeRef(tableRangeRef)
+        if (!tableRange) { setError('표 범위가 올바르지 않습니다. (예: A1:D5)'); return }
+
+        const rowInput = rowInputRef.trim() ? parseCellRef(rowInputRef) : undefined
+        const colInput = colInputRef.trim() ? parseCellRef(colInputRef) : undefined
+
+        if (!rowInput && !colInput) {
+            setError('행 입력 셀 또는 열 입력 셀 중 하나는 반드시 지정해야 합니다.')
+            return
+        }
+
+        if (rowInput === null || colInput === null) {
+            setError('셀 주소 형식이 올바르지 않습니다.')
+            return
+        }
+
+        const params: DataTableParams = {
+            resultFormula: resultCell,
+            tableRange,
+            rowInputCell: rowInput ?? undefined,
+            colInputCell: colInput ?? undefined,
+        }
+
+        setRunning(true)
+        try {
+            await dataTableSolver.solve(sheetId, params, setCell)
+            setDone(true)
+        } catch (err) {
+            setError(String(err))
+        } finally {
+            setRunning(false)
+        }
+    }
+
+    return (
+        <div
+            style={{
+                position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.3)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+            }}
+            onMouseDown={onClose}
+        >
+            <div
+                style={{
+                    background: '#fff', borderRadius: 6, padding: 24, minWidth: 340,
+                    boxShadow: '0 4px 24px rgba(0,0,0,0.18)', fontFamily: 'system-ui, sans-serif',
+                    fontSize: 13,
+                }}
+                onMouseDown={e => e.stopPropagation()}
+            >
+                <h3 style={{ margin: '0 0 16px', fontSize: 15, fontWeight: 600 }}>데이터 표</h3>
+
+                <label style={labelStyle}>결과 수식 셀</label>
+                <input style={inputStyle} placeholder="예: B1" value={resultRef} onChange={e => setResultRef(e.target.value)} />
+
+                <label style={labelStyle}>표 범위</label>
+                <input style={inputStyle} placeholder="예: A3:E8" value={tableRangeRef} onChange={e => setTableRangeRef(e.target.value)} />
+
+                <label style={labelStyle}>행 입력 셀 (선택)</label>
+                <input style={inputStyle} placeholder="예: A1" value={rowInputRef} onChange={e => setRowInputRef(e.target.value)} />
+
+                <label style={labelStyle}>열 입력 셀 (선택)</label>
+                <input style={inputStyle} placeholder="예: B1" value={colInputRef} onChange={e => setColInputRef(e.target.value)} />
+
+                <p style={{ color: '#5f6368', marginBottom: 12, lineHeight: 1.5 }}>
+                    단변수: 행 또는 열 입력 셀만 지정<br />
+                    이변수: 행과 열 입력 셀 모두 지정
+                </p>
+
+                {error && <div style={{ color: '#c0392b', marginBottom: 8 }}>{error}</div>}
+                {done && <div style={{ color: '#1e8e3e', marginBottom: 8 }}>데이터 표가 완성되었습니다.</div>}
+
+                <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                    <button style={btnStyle('#f1f3f4', '#202124')} onClick={onClose}>닫기</button>
+                    <button
+                        style={btnStyle('#1a73e8', '#fff')}
+                        onClick={handleSolve}
+                        disabled={running}
+                    >
+                        {running ? '계산 중…' : '확인'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const labelStyle: React.CSSProperties = {
+    display: 'block', marginBottom: 4, fontWeight: 500, color: '#5f6368',
+}
+
+const inputStyle: React.CSSProperties = {
+    display: 'block', width: '100%', marginBottom: 12,
+    border: '1px solid #dadce0', borderRadius: 4, padding: '6px 8px',
+    fontSize: 13, outline: 'none', boxSizing: 'border-box',
+}
+
+function btnStyle(bg: string, color: string): React.CSSProperties {
+    return {
+        padding: '6px 16px', borderRadius: 4, border: 'none', background: bg,
+        color, cursor: 'pointer', fontSize: 13, fontWeight: 500,
+    }
+}

--- a/packages/frontend/src/components/dialogs/GoalSeekDialog.tsx
+++ b/packages/frontend/src/components/dialogs/GoalSeekDialog.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react'
+import { goalSeekSolver } from '../../core/analysis'
+import type { GoalSeekParams, GoalSeekResult } from '../../core/analysis'
+
+interface Props {
+    sheetId: string
+    onClose: () => void
+}
+
+function parseCellRef(ref: string): { row: number; col: number } | null {
+    const m = ref.trim().toUpperCase().match(/^([A-Z]+)(\d+)$/)
+    if (!m) return null
+    let col = 0
+    for (const ch of m[1]) col = col * 26 + (ch.charCodeAt(0) - 64)
+    return { row: parseInt(m[2], 10) - 1, col: col - 1 }
+}
+
+export function GoalSeekDialog({ sheetId, onClose }: Props) {
+    const [formulaCellRef, setFormulaCellRef] = useState('')
+    const [targetValue, setTargetValue] = useState('')
+    const [changingCellRef, setChangingCellRef] = useState('')
+    const [result, setResult] = useState<GoalSeekResult | null>(null)
+    const [running, setRunning] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const handleSolve = async () => {
+        setError(null)
+        setResult(null)
+
+        const fc = parseCellRef(formulaCellRef)
+        const cc = parseCellRef(changingCellRef)
+        const tv = parseFloat(targetValue)
+
+        if (!fc) { setError('수식 셀 주소가 올바르지 않습니다.'); return }
+        if (!cc) { setError('변경 셀 주소가 올바르지 않습니다.'); return }
+        if (isNaN(tv)) { setError('목표 값이 올바르지 않습니다.'); return }
+
+        const params: GoalSeekParams = {
+            formulaCell: fc,
+            targetValue: tv,
+            changingCell: cc,
+        }
+
+        setRunning(true)
+        try {
+            const res = await goalSeekSolver.solve(sheetId, params)
+            setResult(res)
+        } catch (err) {
+            setError(String(err))
+        } finally {
+            setRunning(false)
+        }
+    }
+
+    return (
+        <div
+            style={{
+                position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.3)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+            }}
+            onMouseDown={onClose}
+        >
+            <div
+                style={{
+                    background: '#fff', borderRadius: 6, padding: 24, minWidth: 320,
+                    boxShadow: '0 4px 24px rgba(0,0,0,0.18)', fontFamily: 'system-ui, sans-serif',
+                    fontSize: 13,
+                }}
+                onMouseDown={e => e.stopPropagation()}
+            >
+                <h3 style={{ margin: '0 0 16px', fontSize: 15, fontWeight: 600 }}>목표값 찾기</h3>
+
+                <label style={labelStyle}>수식 셀</label>
+                <input
+                    style={inputStyle}
+                    placeholder="예: B1"
+                    value={formulaCellRef}
+                    onChange={e => setFormulaCellRef(e.target.value)}
+                />
+
+                <label style={labelStyle}>찾는 값</label>
+                <input
+                    style={inputStyle}
+                    type="number"
+                    placeholder="예: 10"
+                    value={targetValue}
+                    onChange={e => setTargetValue(e.target.value)}
+                />
+
+                <label style={labelStyle}>변경 셀</label>
+                <input
+                    style={inputStyle}
+                    placeholder="예: A1"
+                    value={changingCellRef}
+                    onChange={e => setChangingCellRef(e.target.value)}
+                />
+
+                {error && <div style={{ color: '#c0392b', marginBottom: 8 }}>{error}</div>}
+
+                {result && (
+                    <div style={{ marginBottom: 12, padding: 8, background: result.success ? '#e8f5e9' : '#fce4ec', borderRadius: 4 }}>
+                        {result.success
+                            ? `완료: 변경 셀 = ${result.foundValue?.toFixed(6)} (${result.iterations}회 반복)`
+                            : `수렴 실패 (${result.iterations}회 반복, 오차 ${result.finalDiff.toExponential(2)})`}
+                    </div>
+                )}
+
+                <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 8 }}>
+                    <button style={btnStyle('#f1f3f4', '#202124')} onClick={onClose}>닫기</button>
+                    <button
+                        style={btnStyle('#1a73e8', '#fff')}
+                        onClick={handleSolve}
+                        disabled={running}
+                    >
+                        {running ? '계산 중…' : '확인'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const labelStyle: React.CSSProperties = {
+    display: 'block', marginBottom: 4, fontWeight: 500, color: '#5f6368',
+}
+
+const inputStyle: React.CSSProperties = {
+    display: 'block', width: '100%', marginBottom: 12,
+    border: '1px solid #dadce0', borderRadius: 4, padding: '6px 8px',
+    fontSize: 13, outline: 'none', boxSizing: 'border-box',
+}
+
+function btnStyle(bg: string, color: string): React.CSSProperties {
+    return {
+        padding: '6px 16px', borderRadius: 4, border: 'none', background: bg,
+        color, cursor: 'pointer', fontSize: 13, fontWeight: 500,
+    }
+}

--- a/packages/frontend/src/components/dialogs/ScenarioDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ScenarioDialog.tsx
@@ -1,0 +1,220 @@
+import React, { useState } from 'react'
+import { scenarioManager } from '../../core/analysis'
+import type { Scenario } from '../../core/analysis'
+import type { CellData } from '@cellix/shared'
+
+interface Props {
+    sheetId: string
+    setCell: (row: number, col: number, data: CellData) => void
+    getCell: (row: number, col: number) => CellData | null
+    onClose: () => void
+}
+
+function parseCellRef(ref: string): { row: number; col: number } | null {
+    const m = ref.trim().toUpperCase().match(/^([A-Z]+)(\d+)$/)
+    if (!m) return null
+    let col = 0
+    for (const ch of m[1]) col = col * 26 + (ch.charCodeAt(0) - 64)
+    return { row: parseInt(m[2], 10) - 1, col: col - 1 }
+}
+
+
+type DialogMode = 'list' | 'add'
+
+export function ScenarioDialog({ sheetId, setCell, getCell, onClose }: Props) {
+    const [mode, setMode] = useState<DialogMode>('list')
+    const [scenarios, setScenarios] = useState<Scenario[]>(() =>
+        scenarioManager.getScenariosForSheet(sheetId)
+    )
+
+    // Add form state
+    const [newName, setNewName] = useState('')
+    const [cellRefs, setCellRefs] = useState<string[]>([''])
+    const [cellValues, setCellValues] = useState<string[]>([''])
+    const [comment, setComment] = useState('')
+    const [formError, setFormError] = useState<string | null>(null)
+
+    const refresh = () => setScenarios(scenarioManager.getScenariosForSheet(sheetId))
+
+    const handleShow = (id: string) => {
+        scenarioManager.showScenario(sheetId, id, setCell)
+        onClose()
+    }
+
+    const handleDelete = (id: string) => {
+        scenarioManager.deleteScenario(sheetId, id)
+        refresh()
+    }
+
+    const handleAdd = () => {
+        setFormError(null)
+        if (!newName.trim()) { setFormError('시나리오 이름을 입력하세요.'); return }
+
+        const changingCells: Scenario['changingCells'] = []
+        for (let i = 0; i < cellRefs.length; i++) {
+            const ref = cellRefs[i]
+            const val = cellValues[i]
+            if (!ref.trim()) continue
+            const parsed = parseCellRef(ref)
+            if (!parsed) { setFormError(`셀 주소 "${ref}" 가 올바르지 않습니다.`); return }
+            const numVal = Number(val)
+            changingCells.push({
+                row: parsed.row,
+                col: parsed.col,
+                sheetId,
+                value: val === '' ? null : isNaN(numVal) ? val : numVal,
+            })
+        }
+
+        if (changingCells.length === 0) { setFormError('변경 셀을 하나 이상 입력하세요.'); return }
+
+        scenarioManager.addScenario(sheetId, { name: newName.trim(), changingCells, comment: comment || undefined })
+        refresh()
+        setMode('list')
+        setNewName(''); setCellRefs(['']); setCellValues(['']); setComment('')
+    }
+
+    const handleSummary = () => {
+        const summaryId = `summary_${sheetId}_${Date.now()}`
+        scenarioManager.generateSummary(
+            sheetId,
+            [],
+            (targetSheetId, row, col, data) => {
+                if (targetSheetId === summaryId) setCell(row, col, data)
+            },
+            summaryId,
+            getCell,
+        )
+        onClose()
+    }
+
+    return (
+        <div
+            style={{
+                position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.3)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+            }}
+            onMouseDown={onClose}
+        >
+            <div
+                style={{
+                    background: '#fff', borderRadius: 6, padding: 24, minWidth: 380,
+                    boxShadow: '0 4px 24px rgba(0,0,0,0.18)', fontFamily: 'system-ui, sans-serif',
+                    fontSize: 13,
+                }}
+                onMouseDown={e => e.stopPropagation()}
+            >
+                {mode === 'list' ? (
+                    <>
+                        <h3 style={{ margin: '0 0 16px', fontSize: 15, fontWeight: 600 }}>시나리오 관리자</h3>
+
+                        {scenarios.length === 0
+                            ? <p style={{ color: '#5f6368', marginBottom: 12 }}>시나리오가 없습니다.</p>
+                            : (
+                                <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 12px' }}>
+                                    {scenarios.map(s => (
+                                        <li key={s.id} style={{
+                                            display: 'flex', alignItems: 'center', gap: 8,
+                                            padding: '6px 0', borderBottom: '1px solid #f1f3f4',
+                                        }}>
+                                            <span style={{ flex: 1 }}>{s.name}</span>
+                                            <button style={smallBtn('#1a73e8', '#fff')} onClick={() => handleShow(s.id)}>표시</button>
+                                            <button style={smallBtn('#ea4335', '#fff')} onClick={() => handleDelete(s.id)}>삭제</button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )
+                        }
+
+                        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginTop: 4 }}>
+                            <button style={btnStyle('#1a73e8', '#fff')} onClick={() => setMode('add')}>+ 추가</button>
+                            <button style={btnStyle('#f1f3f4', '#202124')} onClick={handleSummary}>요약 보고서</button>
+                            <button style={{ ...btnStyle('#f1f3f4', '#202124'), marginLeft: 'auto' }} onClick={onClose}>닫기</button>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <h3 style={{ margin: '0 0 16px', fontSize: 15, fontWeight: 600 }}>시나리오 추가</h3>
+
+                        <label style={labelStyle}>시나리오 이름</label>
+                        <input style={inputStyle} value={newName} onChange={e => setNewName(e.target.value)} />
+
+                        <label style={labelStyle}>변경 셀</label>
+                        {cellRefs.map((ref, i) => (
+                            <div key={i} style={{ display: 'flex', gap: 6, marginBottom: 6 }}>
+                                <input
+                                    style={{ ...inputStyle, marginBottom: 0, width: 90 }}
+                                    placeholder={`A${i + 1}`}
+                                    value={ref}
+                                    onChange={e => {
+                                        const arr = [...cellRefs]; arr[i] = e.target.value; setCellRefs(arr)
+                                        const cell = parseCellRef(e.target.value)
+                                        if (cell) {
+                                            const existing = getCell(cell.row, cell.col)
+                                            const vals = [...cellValues]
+                                            vals[i] = existing?.value != null ? String(existing.value) : ''
+                                            setCellValues(vals)
+                                        }
+                                    }}
+                                />
+                                <input
+                                    style={{ ...inputStyle, marginBottom: 0, flex: 1 }}
+                                    placeholder="값"
+                                    value={cellValues[i]}
+                                    onChange={e => { const arr = [...cellValues]; arr[i] = e.target.value; setCellValues(arr) }}
+                                />
+                                {i > 0 && (
+                                    <button
+                                        style={{ ...smallBtn('#ea4335', '#fff'), padding: '4px 8px' }}
+                                        onClick={() => {
+                                            setCellRefs(cellRefs.filter((_, idx) => idx !== i))
+                                            setCellValues(cellValues.filter((_, idx) => idx !== i))
+                                        }}
+                                    >✕</button>
+                                )}
+                            </div>
+                        ))}
+                        <button
+                            style={{ ...smallBtn('#5f6368', '#fff'), marginBottom: 12 }}
+                            onClick={() => { setCellRefs([...cellRefs, '']); setCellValues([...cellValues, '']) }}
+                        >+ 셀 추가</button>
+
+                        <label style={labelStyle}>메모 (선택)</label>
+                        <input style={inputStyle} value={comment} onChange={e => setComment(e.target.value)} />
+
+                        {formError && <div style={{ color: '#c0392b', marginBottom: 8 }}>{formError}</div>}
+
+                        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                            <button style={btnStyle('#f1f3f4', '#202124')} onClick={() => setMode('list')}>취소</button>
+                            <button style={btnStyle('#1a73e8', '#fff')} onClick={handleAdd}>저장</button>
+                        </div>
+                    </>
+                )}
+            </div>
+        </div>
+    )
+}
+
+const labelStyle: React.CSSProperties = {
+    display: 'block', marginBottom: 4, fontWeight: 500, color: '#5f6368',
+}
+
+const inputStyle: React.CSSProperties = {
+    display: 'block', width: '100%', marginBottom: 12,
+    border: '1px solid #dadce0', borderRadius: 4, padding: '6px 8px',
+    fontSize: 13, outline: 'none', boxSizing: 'border-box',
+}
+
+function btnStyle(bg: string, color: string): React.CSSProperties {
+    return {
+        padding: '6px 16px', borderRadius: 4, border: 'none', background: bg,
+        color, cursor: 'pointer', fontSize: 13, fontWeight: 500,
+    }
+}
+
+function smallBtn(bg: string, color: string): React.CSSProperties {
+    return {
+        padding: '3px 10px', borderRadius: 4, border: 'none', background: bg,
+        color, cursor: 'pointer', fontSize: 12, fontWeight: 500,
+    }
+}

--- a/packages/frontend/src/core/analysis/DataTableSolver.ts
+++ b/packages/frontend/src/core/analysis/DataTableSolver.ts
@@ -1,0 +1,92 @@
+import type { CellData } from '@cellix/shared'
+import { formulaEngine } from '../../workers'
+
+export interface DataTableParams {
+    resultFormula: { row: number; col: number }
+    rowInputCell?: { row: number; col: number }
+    colInputCell?: { row: number; col: number }
+    tableRange: {
+        startRow: number
+        startCol: number
+        endRow: number
+        endCol: number
+    }
+}
+
+/**
+ * 데이터 표: 1~2개 입력 셀 변화에 따른 수식 결과 테이블 생성.
+ *
+ * 단변수 (열 입력만 있는 경우):
+ *   - 표의 첫 번째 행이 입력값 목록 (startCol+1 ~ endCol)
+ *   - 결과는 startRow+1 행에 채워짐
+ *
+ * 단변수 (행 입력만 있는 경우):
+ *   - 표의 첫 번째 열이 입력값 목록 (startRow+1 ~ endRow)
+ *   - 결과는 startCol+1 열에 채워짐
+ *
+ * 이변수 (행+열 입력 모두 있는 경우):
+ *   - 첫 행(startCol+1~endCol): 열 입력값
+ *   - 첫 열(startRow+1~endRow): 행 입력값
+ *   - 내부 셀: 각 조합의 결과
+ */
+export class DataTableSolver {
+    async solve(
+        sheetId: string,
+        params: DataTableParams,
+        setCell: (row: number, col: number, data: CellData) => void,
+    ): Promise<void> {
+        const { resultFormula, rowInputCell, colInputCell, tableRange } = params
+        const { startRow, startCol, endRow, endCol } = tableRange
+
+        if (!rowInputCell && !colInputCell) return
+
+        if (rowInputCell && !colInputCell) {
+            // 단변수: 행 입력 (첫 열에 입력값, 두 번째 열부터 결과)
+            for (let r = startRow + 1; r <= endRow; r++) {
+                const inputVal = await this._getCellNumericValue(sheetId, r, startCol)
+                await formulaEngine.setCell(sheetId, rowInputCell.row, rowInputCell.col, inputVal)
+                const result = await formulaEngine.getCellValue(
+                    sheetId, resultFormula.row, resultFormula.col,
+                )
+                const resultVal = result.t === 'n' ? (result.v as number) : null
+                setCell(r, startCol + 1, { value: resultVal })
+            }
+        } else if (!rowInputCell && colInputCell) {
+            // 단변수: 열 입력 (첫 행에 입력값, 두 번째 행부터 결과)
+            for (let c = startCol + 1; c <= endCol; c++) {
+                const inputVal = await this._getCellNumericValue(sheetId, startRow, c)
+                await formulaEngine.setCell(sheetId, colInputCell.row, colInputCell.col, inputVal)
+                const result = await formulaEngine.getCellValue(
+                    sheetId, resultFormula.row, resultFormula.col,
+                )
+                const resultVal = result.t === 'n' ? (result.v as number) : null
+                setCell(startRow + 1, c, { value: resultVal })
+            }
+        } else if (rowInputCell && colInputCell) {
+            // 이변수
+            for (let r = startRow + 1; r <= endRow; r++) {
+                const rowInputVal = await this._getCellNumericValue(sheetId, r, startCol)
+                await formulaEngine.setCell(sheetId, rowInputCell.row, rowInputCell.col, rowInputVal)
+
+                for (let c = startCol + 1; c <= endCol; c++) {
+                    const colInputVal = await this._getCellNumericValue(sheetId, startRow, c)
+                    await formulaEngine.setCell(sheetId, colInputCell.row, colInputCell.col, colInputVal)
+
+                    const result = await formulaEngine.getCellValue(
+                        sheetId, resultFormula.row, resultFormula.col,
+                    )
+                    const resultVal = result.t === 'n' ? (result.v as number) : null
+                    setCell(r, c, { value: resultVal })
+                }
+            }
+        }
+    }
+
+    private async _getCellNumericValue(sheetId: string, row: number, col: number): Promise<number | null> {
+        const result = await formulaEngine.getCellValue(sheetId, row, col)
+        if (result.t === 'n') return result.v as number
+        return null
+    }
+}
+
+export const dataTableSolver = new DataTableSolver()

--- a/packages/frontend/src/core/analysis/GoalSeekSolver.ts
+++ b/packages/frontend/src/core/analysis/GoalSeekSolver.ts
@@ -1,0 +1,141 @@
+import { formulaEngine } from '../../workers'
+
+export interface GoalSeekParams {
+    formulaCell: { row: number; col: number }
+    targetValue: number
+    changingCell: { row: number; col: number }
+}
+
+export interface GoalSeekResult {
+    success: boolean
+    foundValue?: number
+    iterations: number
+    finalDiff: number
+}
+
+export class GoalSeekSolver {
+    async solve(
+        sheetId: string,
+        params: GoalSeekParams,
+        maxIterations = 1000,
+        tolerance = 0.001,
+    ): Promise<GoalSeekResult> {
+        const { formulaCell, targetValue, changingCell } = params
+
+        const evaluate = async (x: number): Promise<number> => {
+            await formulaEngine.setCell(sheetId, changingCell.row, changingCell.col, x)
+            const result = await formulaEngine.getCellValue(sheetId, formulaCell.row, formulaCell.col)
+            if (result.t !== 'n' || result.v === undefined) return NaN
+            return result.v as number
+        }
+
+        // 초기 탐색 범위 설정
+        let lo = -1e6
+        let hi = 1e6
+
+        // 초기값으로 현재 수식 셀 값 확인
+        const f0 = await evaluate(0)
+        if (isNaN(f0)) {
+            return { success: false, iterations: 0, finalDiff: Infinity }
+        }
+
+        // 이분법으로 lo/hi의 부호가 반대인 구간 탐색
+        let fLo = await evaluate(lo) - targetValue
+        let fHi = await evaluate(hi) - targetValue
+
+        // 같은 부호이면 범위 확장 시도
+        if (Math.sign(fLo) === Math.sign(fHi)) {
+            const candidates = [-1e9, -1e4, -100, -1, 0, 1, 100, 1e4, 1e9]
+            let found = false
+            for (let i = 0; i < candidates.length - 1 && !found; i++) {
+                const a = candidates[i]
+                const b = candidates[i + 1]
+                const fa = await evaluate(a) - targetValue
+                const fb = await evaluate(b) - targetValue
+                if (Math.sign(fa) !== Math.sign(fb)) {
+                    lo = a; hi = b; fLo = fa; fHi = fb
+                    found = true
+                }
+            }
+            if (!found) {
+                // Newton-Raphson 단독 시도
+                return this._newtonRaphson(sheetId, params, evaluate, maxIterations, tolerance)
+            }
+        }
+
+        let iterations = 0
+        let mid = (lo + hi) / 2
+        let fMid = await evaluate(mid) - targetValue
+
+        // 이분법 + 뉴턴-랩슨 혼합
+        while (iterations < maxIterations && Math.abs(fMid) > tolerance) {
+            iterations++
+
+            // 뉴턴-랩슨 스텝 시도 (수렴 가속)
+            const dx = (hi - lo) * 1e-6
+            const fMidPlusDx = await evaluate(mid + dx) - targetValue
+            const derivative = (fMidPlusDx - fMid) / dx
+
+            let newtonStep = mid
+            if (Math.abs(derivative) > 1e-12) {
+                newtonStep = mid - fMid / derivative
+            }
+
+            // 뉴턴 스텝이 구간 안에 있으면 사용, 아니면 이분법
+            if (newtonStep > lo && newtonStep < hi) {
+                mid = newtonStep
+            } else {
+                mid = (lo + hi) / 2
+            }
+
+            fMid = await evaluate(mid) - targetValue
+
+            if (Math.sign(fMid) === Math.sign(fLo)) {
+                lo = mid; fLo = fMid
+            } else {
+                hi = mid; fHi = fMid
+            }
+        }
+
+        const success = Math.abs(fMid) <= tolerance
+        if (success) {
+            // 최종값을 변경 셀에 저장
+            await formulaEngine.setCell(sheetId, changingCell.row, changingCell.col, mid)
+        }
+
+        return { success, foundValue: mid, iterations, finalDiff: Math.abs(fMid) }
+    }
+
+    private async _newtonRaphson(
+        sheetId: string,
+        params: GoalSeekParams,
+        evaluate: (x: number) => Promise<number>,
+        maxIterations: number,
+        tolerance: number,
+    ): Promise<GoalSeekResult> {
+        const { targetValue, changingCell } = params
+        let x = 0
+        let iterations = 0
+
+        while (iterations < maxIterations) {
+            iterations++
+            const fx = await evaluate(x) - targetValue
+            if (Math.abs(fx) <= tolerance) {
+                await formulaEngine.setCell(sheetId, changingCell.row, changingCell.col, x)
+                return { success: true, foundValue: x, iterations, finalDiff: Math.abs(fx) }
+            }
+
+            const dx = Math.max(Math.abs(x) * 1e-6, 1e-8)
+            const fxdx = await evaluate(x + dx) - targetValue
+            const derivative = (fxdx - fx) / dx
+
+            if (Math.abs(derivative) < 1e-12) break
+            x = x - fx / derivative
+        }
+
+        const finalFx = await evaluate(x) - targetValue
+        return { success: false, foundValue: x, iterations, finalDiff: Math.abs(finalFx) }
+    }
+}
+
+export const goalSeekSolver = new GoalSeekSolver()

--- a/packages/frontend/src/core/analysis/ScenarioManager.ts
+++ b/packages/frontend/src/core/analysis/ScenarioManager.ts
@@ -1,0 +1,131 @@
+import type { CellData } from '@cellix/shared'
+
+export interface Scenario {
+    id: string
+    name: string
+    changingCells: Array<{
+        row: number
+        col: number
+        sheetId: string
+        value: string | number | null
+    }>
+    comment?: string
+}
+
+export class ScenarioManager {
+    private readonly scenarios = new Map<string, Scenario[]>()
+
+    addScenario(sheetId: string, scenario: Omit<Scenario, 'id'>): string {
+        const id = crypto.randomUUID()
+        const list = this.scenarios.get(sheetId) ?? []
+        list.push({ ...scenario, id })
+        this.scenarios.set(sheetId, list)
+        return id
+    }
+
+    deleteScenario(sheetId: string, id: string): void {
+        const list = this.scenarios.get(sheetId)
+        if (!list) return
+        const next = list.filter(s => s.id !== id)
+        this.scenarios.set(sheetId, next)
+    }
+
+    showScenario(
+        sheetId: string,
+        id: string,
+        setCell: (row: number, col: number, data: CellData) => void,
+    ): void {
+        const list = this.scenarios.get(sheetId) ?? []
+        const scenario = list.find(s => s.id === id)
+        if (!scenario) return
+
+        for (const cell of scenario.changingCells) {
+            setCell(cell.row, cell.col, { value: cell.value })
+        }
+    }
+
+    getScenariosForSheet(sheetId: string): Scenario[] {
+        return this.scenarios.get(sheetId) ?? []
+    }
+
+    /**
+     * 시나리오 요약 보고서 생성.
+     * 새 시트(summarySheetId)에 비교표를 기록.
+     * 행: 변경 셀 레이블, 결과 셀 값
+     * 열: 각 시나리오
+     */
+    generateSummary(
+        sheetId: string,
+        resultCells: Array<{ row: number; col: number }>,
+        setCell: (targetSheetId: string, row: number, col: number, data: CellData) => void,
+        summarySheetId: string,
+        getCell: (row: number, col: number) => CellData | null,
+    ): void {
+        const list = this.scenarios.get(sheetId) ?? []
+        if (list.length === 0) return
+
+        let row = 0
+
+        // 헤더 행: 빈 셀 + 시나리오 이름들
+        setCell(summarySheetId, row, 0, { value: '변경 셀 / 시나리오' })
+        for (let i = 0; i < list.length; i++) {
+            setCell(summarySheetId, row, i + 1, { value: list[i].name })
+        }
+        row++
+
+        // 변경 셀 행들
+        const allChangingCells = new Map<string, { row: number; col: number }>()
+        for (const scenario of list) {
+            for (const cell of scenario.changingCells) {
+                const key = `${cell.row}:${cell.col}`
+                if (!allChangingCells.has(key)) {
+                    allChangingCells.set(key, { row: cell.row, col: cell.col })
+                }
+            }
+        }
+
+        for (const [, cell] of allChangingCells) {
+            const colLetter = _colToLetter(cell.col)
+            setCell(summarySheetId, row, 0, { value: `${colLetter}${cell.row + 1}` })
+
+            for (let i = 0; i < list.length; i++) {
+                const found = list[i].changingCells.find(
+                    c => c.row === cell.row && c.col === cell.col,
+                )
+                setCell(summarySheetId, row, i + 1, { value: found?.value ?? null })
+            }
+            row++
+        }
+
+        // 구분선
+        row++
+
+        // 결과 셀 행들 (현재 시트의 현재 값)
+        setCell(summarySheetId, row, 0, { value: '결과 셀' })
+        row++
+
+        for (const rc of resultCells) {
+            const colLetter = _colToLetter(rc.col)
+            setCell(summarySheetId, row, 0, { value: `${colLetter}${rc.row + 1}` })
+
+            const currentVal = getCell(rc.row, rc.col)
+            for (let i = 0; i < list.length; i++) {
+                setCell(summarySheetId, row, i + 1, { value: currentVal?.value ?? null })
+            }
+            row++
+        }
+    }
+}
+
+function _colToLetter(col: number): string {
+    let result = ''
+    let n = col + 1
+    while (n > 0) {
+        const r = (n - 1) % 26
+        result = String.fromCharCode(65 + r) + result
+        n = Math.floor((n - 1) / 26)
+    }
+    return result
+}
+
+export const scenarioManager = new ScenarioManager()

--- a/packages/frontend/src/core/analysis/index.ts
+++ b/packages/frontend/src/core/analysis/index.ts
@@ -1,0 +1,8 @@
+export { GoalSeekSolver, goalSeekSolver } from './GoalSeekSolver'
+export type { GoalSeekParams, GoalSeekResult } from './GoalSeekSolver'
+
+export { ScenarioManager, scenarioManager } from './ScenarioManager'
+export type { Scenario } from './ScenarioManager'
+
+export { DataTableSolver, dataTableSolver } from './DataTableSolver'
+export type { DataTableParams } from './DataTableSolver'

--- a/packages/frontend/src/core/input/InputManager.ts
+++ b/packages/frontend/src/core/input/InputManager.ts
@@ -44,6 +44,7 @@ export class InputManager {
     private readonly _editListeners = new Set<EditListener>()
     private readonly _fillListeners = new Set<FillListener>()
     private readonly _onCommit: (row: number, col: number, value: string) => void
+    private _onCreateTable: (() => void) | undefined
 
     // 이벤트 핸들러 (removeEventListener 에서 동일 참조 필요)
     private readonly _onMouseDown: (e: MouseEvent) => void
@@ -82,6 +83,10 @@ export class InputManager {
     }
 
     // ── 퍼블릭 API ──────────────────────────────────────────────────────────────
+
+    setCreateTableCallback(cb: () => void): void {
+        this._onCreateTable = cb
+    }
 
     subscribeEdit(listener: EditListener): () => void {
         this._editListeners.add(listener)
@@ -395,6 +400,12 @@ export class InputManager {
     }
 
     private _handleNavKeyDown(e: KeyboardEvent): void {
+        if (e.ctrlKey && e.key === 't') {
+            e.preventDefault()
+            this._onCreateTable?.()
+            return
+        }
+
         if (e.key === 'F2') {
             const active = this._selection.getActiveCell()
             if (active) this._enterEditMode(active.row, active.col)

--- a/packages/frontend/src/core/renderer/GridRenderer.ts
+++ b/packages/frontend/src/core/renderer/GridRenderer.ts
@@ -5,6 +5,7 @@ import { NumberFormatter } from '../style/NumberFormatter'
 import { conditionalFormatManager } from '../conditional'
 import type { CondFmtCellResult } from '../conditional'
 import { filterManager } from '../data'
+import { tableManager, TableStyleRenderer } from '../table'
 
 function borderLineWidth(style: BorderStyle): number {
     switch (style) {
@@ -103,8 +104,12 @@ export class GridRenderer {
 
                 const baseStyle = styleManager.getStyle(sheetId, row, col)
 
-                // 배경색: 조건부 서식이 있으면 우선 적용
-                const bgColor = cfResult.style?.backgroundColor ?? baseStyle.backgroundColor
+                // 표 스타일 (우선순위 최하위)
+                const _tbl = tableManager.getTableAt(sheetId, row, col)
+                const _tblStyle = _tbl ? TableStyleRenderer.getCellStyleForTable(_tbl, row, col) : null
+
+                // 배경색: 조건부 서식 > 명시적 스타일 > 표 스타일
+                const bgColor = cfResult.style?.backgroundColor ?? baseStyle.backgroundColor ?? _tblStyle?.backgroundColor
                 if (bgColor) {
                     ctx.fillStyle = bgColor
                     ctx.fillRect(x, y, w, h)
@@ -151,16 +156,24 @@ export class GridRenderer {
                 const baseStyle = styleManager.getStyle(sheetId, row, col)
                 const cfResult = cfCache.get(`${row}:${col}`) ?? {}
 
-                // 조건부 서식 스타일을 baseStyle에 오버레이 (조건부 서식 우선)
+                // 표 스타일 조회 (배경 패스와 별도로 다시 조회 — 텍스트 패스 루프)
+                const tblAt = tableManager.getTableAt(sheetId, row, col)
+                const tblStyle = tblAt ? TableStyleRenderer.getCellStyleForTable(tblAt, row, col) : null
+
+                // 우선순위: cfResult > baseStyle > tblStyle
+                const mergedBase: CellStyle = tblStyle
+                    ? { ...tblStyle, ...baseStyle, font: { ...tblStyle.font, ...baseStyle.font } }
+                    : baseStyle
+
                 const style: CellStyle = cfResult.style
                     ? {
-                        ...baseStyle,
+                        ...mergedBase,
                         ...cfResult.style,
                         font: cfResult.style.font
-                            ? { ...baseStyle.font, ...cfResult.style.font }
-                            : baseStyle.font,
+                            ? { ...mergedBase.font, ...cfResult.style.font }
+                            : mergedBase.font,
                     }
-                    : baseStyle
+                    : mergedBase
 
                 const rawValue = calcVal !== null && calcVal !== undefined
                     ? calcVal
@@ -228,12 +241,23 @@ export class GridRenderer {
                     }
                 }
 
-                // 4f. 자동 필터 ▼ 아이콘 (헤더 행)
+                // 4f. 자동 필터 ▼ 아이콘 (헤더 행 — filterManager 기반)
                 const _af = filterManager.getAutoFilter(sheetId)
                 if (_af && row === _af.headerRow && col >= _af.startCol && col <= _af.endCol) {
                     const hasFilter = _af.criteria.has(col)
                     ctx.save()
                     ctx.fillStyle = hasFilter ? '#1a73e8' : '#5f6368'
+                    ctx.font = `9px system-ui, -apple-system, sans-serif`
+                    ctx.textAlign = 'right'
+                    ctx.textBaseline = 'middle'
+                    ctx.fillText('▼', x + w - 3, y + h / 2)
+                    ctx.restore()
+                }
+
+                // 4f-2. 표 헤더 행 ▼ 아이콘
+                if (tblAt && tblAt.showHeaderRow && row === tblAt.range.start.row) {
+                    ctx.save()
+                    ctx.fillStyle = '#5f6368'
                     ctx.font = `9px system-ui, -apple-system, sans-serif`
                     ctx.textAlign = 'right'
                     ctx.textBaseline = 'middle'

--- a/packages/frontend/src/core/table/StructuredRefDisplay.ts
+++ b/packages/frontend/src/core/table/StructuredRefDisplay.ts
@@ -1,0 +1,44 @@
+import type { TableDefinition } from '@cellix/shared'
+
+/**
+ * 셀 범위를 구조적 참조 문자열로 역변환.
+ * 주어진 범위가 어떤 표의 특정 열 데이터 범위와 정확히 일치하면 "TableName[ColumnName]" 반환.
+ * 일치하지 않으면 null (일반 A1 표기 유지).
+ */
+export function cellRangeToStructuredRef(
+    sheetId: string,
+    startRow: number,
+    startCol: number,
+    endRow: number,
+    endCol: number,
+    tables: TableDefinition[],
+): string | null {
+    for (const table of tables) {
+        if (table.sheetId !== sheetId) continue
+
+        const tStartRow = table.range.start.row
+        const tEndRow = table.range.end.row
+        const tStartCol = table.range.start.col
+
+        // 단일 열 범위만 구조적 참조로 변환 (startCol === endCol)
+        if (startCol !== endCol) continue
+
+        // 열이 표 범위 안에 있는지 확인
+        if (startCol < tStartCol || startCol > table.range.end.col) continue
+
+        // 데이터 범위 (헤더/합계 행 제외)
+        const dataStartRow = table.showHeaderRow ? tStartRow + 1 : tStartRow
+        const dataEndRow = table.showTotalRow ? tEndRow - 1 : tEndRow
+
+        if (startRow !== dataStartRow || endRow !== dataEndRow) continue
+
+        // 해당 열의 TableColumn 찾기
+        const colIndex = startCol - tStartCol
+        const column = table.columns.find(c => c.index === colIndex)
+        if (!column) continue
+
+        return `${table.name}[${column.name}]`
+    }
+
+    return null
+}

--- a/packages/frontend/src/core/table/TableManager.ts
+++ b/packages/frontend/src/core/table/TableManager.ts
@@ -1,0 +1,280 @@
+import type { CellData, TableDefinition, TableColumn } from '@cellix/shared'
+import { formulaEngine } from '../../workers'
+
+export class TableManager {
+    private readonly tables = new Map<string, TableDefinition>()
+    private readonly listeners = new Set<() => void>()
+
+    async createTable(
+        sheetId: string,
+        startRow: number,
+        startCol: number,
+        endRow: number,
+        endCol: number,
+        getCell: (row: number, col: number) => CellData | null,
+        options?: { hasHeaders?: boolean; styleName?: string },
+    ): Promise<TableDefinition> {
+        const hasHeaders = options?.hasHeaders ?? this._detectHeaders(startRow, startCol, endCol, getCell)
+
+        const columns: TableColumn[] = []
+        for (let c = startCol; c <= endCol; c++) {
+            const headerCell = hasHeaders ? getCell(startRow, c) : null
+            columns.push({
+                index: c - startCol,
+                name: String(headerCell?.value ?? `Column${c - startCol + 1}`),
+            })
+        }
+
+        const table: TableDefinition = {
+            id: crypto.randomUUID(),
+            name: this._generateName(),
+            sheetId,
+            range: {
+                start: { row: startRow, col: startCol, sheetId },
+                end: { row: endRow, col: endCol, sheetId },
+            },
+            columns,
+            styleName: options?.styleName ?? 'TableStyleLight1',
+            showHeaderRow: hasHeaders,
+            showTotalRow: false,
+            showBandedRows: true,
+            showBandedCols: false,
+            showFirstColumnStripe: false,
+            showLastColumnStripe: false,
+        }
+
+        this.tables.set(table.id, table)
+
+        try {
+            await formulaEngine.registerTable(JSON.stringify({
+                id: table.id,
+                name: table.name,
+                sheet_id: table.sheetId,
+                start_row: table.range.start.row,
+                start_col: table.range.start.col,
+                end_row: table.range.end.row,
+                end_col: table.range.end.col,
+                has_header: table.showHeaderRow,
+                has_total: table.showTotalRow,
+                columns: table.columns.map(c => c.name),
+            }))
+        } catch (err) {
+            console.warn('[TableManager] WASM registerTable failed:', err)
+        }
+
+        this._notify()
+        return table
+    }
+
+    async deleteTable(tableId: string): Promise<void> {
+        this.tables.delete(tableId)
+        try {
+            await formulaEngine.unregisterTable(tableId)
+        } catch (err) {
+            console.warn('[TableManager] WASM unregisterTable failed:', err)
+        }
+        this._notify()
+    }
+
+    resizeTable(tableId: string, newEndRow: number, newEndCol: number): void {
+        const table = this.tables.get(tableId)
+        if (!table) return
+        this.tables.set(tableId, {
+            ...table,
+            range: { ...table.range, end: { ...table.range.end, row: newEndRow, col: newEndCol } },
+        })
+        this._notify()
+    }
+
+    toggleTotalRow(
+        tableId: string,
+        setCell: (row: number, col: number, data: CellData) => void,
+    ): void {
+        const table = this.tables.get(tableId)
+        if (!table) return
+
+        if (table.showTotalRow) {
+            // Remove total row: clear cells and shrink range
+            const totalRow = table.range.end.row
+            for (let c = table.range.start.col; c <= table.range.end.col; c++) {
+                setCell(totalRow, c, { value: null })
+            }
+            this.tables.set(tableId, {
+                ...table,
+                range: { ...table.range, end: { ...table.range.end, row: totalRow - 1 } },
+                showTotalRow: false,
+            })
+        } else {
+            // Add total row: extend range and insert formulas
+            const newTotalRow = table.range.end.row + 1
+            const headerRow = table.range.start.row
+            const dataStartRow = table.showHeaderRow ? headerRow + 1 : headerRow
+            const dataEndRow = table.range.end.row
+
+            for (let i = 0; i < table.columns.length; i++) {
+                const col = table.columns[i]
+                const c = table.range.start.col + i
+                const func = col.totalRowFunction ?? 'sum'
+
+                if (func === 'none') {
+                    if (col.totalRowLabel) {
+                        setCell(newTotalRow, c, { value: col.totalRowLabel })
+                    }
+                } else {
+                    const r1 = dataStartRow + 1  // 1-based for formula
+                    const r2 = dataEndRow + 1
+                    const colLetter = this._colToLetter(c)
+                    const funcName = func === 'count' ? 'COUNT'
+                        : func === 'average' ? 'AVERAGE'
+                        : func === 'min' ? 'MIN'
+                        : func === 'max' ? 'MAX'
+                        : 'SUM'
+                    setCell(newTotalRow, c, {
+                        value: null,
+                        formula: `=${funcName}(${colLetter}${r1}:${colLetter}${r2})`,
+                    })
+                }
+            }
+
+            this.tables.set(tableId, {
+                ...table,
+                range: { ...table.range, end: { ...table.range.end, row: newTotalRow } },
+                showTotalRow: true,
+            })
+        }
+        this._notify()
+    }
+
+    renameTable(tableId: string, name: string): void {
+        if (!name || /\s/.test(name)) throw new Error('표 이름에 공백이 없어야 합니다')
+        if (/^[A-Za-z]+\d+$/.test(name)) throw new Error('셀 주소와 같은 이름은 사용할 수 없습니다')
+
+        const existing = new Set(
+            [...this.tables.values()].filter(t => t.id !== tableId).map(t => t.name)
+        )
+        if (existing.has(name)) throw new Error(`이름 "${name}"은 이미 사용 중입니다`)
+
+        const table = this.tables.get(tableId)
+        if (!table) return
+        this.tables.set(tableId, { ...table, name })
+        this._notify()
+    }
+
+    addColumn(
+        tableId: string,
+        position: number | undefined,
+        setCell: (row: number, col: number, data: CellData) => void,
+    ): void {
+        const table = this.tables.get(tableId)
+        if (!table) return
+
+        const newColIdx = position ?? table.columns.length
+        const absoluteCol = table.range.end.col + 1
+        const newColumn: TableColumn = {
+            index: newColIdx,
+            name: `Column ${table.columns.length + 1}`,
+        }
+
+        if (table.showHeaderRow) {
+            setCell(table.range.start.row, absoluteCol, { value: newColumn.name })
+        }
+
+        this.tables.set(tableId, {
+            ...table,
+            range: { ...table.range, end: { ...table.range.end, col: absoluteCol } },
+            columns: [...table.columns, newColumn],
+        })
+        this._notify()
+    }
+
+    checkAutoExpand(
+        sheetId: string,
+        row: number,
+        col: number,
+        _getCell: (row: number, col: number) => CellData | null,
+    ): string | null {
+        for (const table of this.tables.values()) {
+            if (table.sheetId !== sheetId) continue
+            const nextRow = table.range.end.row + 1
+            if (row !== nextRow) continue
+            if (col < table.range.start.col || col > table.range.end.col) continue
+            return table.id
+        }
+        return null
+    }
+
+    expandTable(
+        tableId: string,
+        _setCell: (row: number, col: number, data: CellData | null) => void,
+    ): void {
+        const table = this.tables.get(tableId)
+        if (!table) return
+        this.tables.set(tableId, {
+            ...table,
+            range: { ...table.range, end: { ...table.range.end, row: table.range.end.row + 1 } },
+        })
+        this._notify()
+    }
+
+    getTableAt(sheetId: string, row: number, col: number): TableDefinition | null {
+        for (const table of this.tables.values()) {
+            if (table.sheetId !== sheetId) continue
+            const r1 = Math.min(table.range.start.row, table.range.end.row)
+            const r2 = Math.max(table.range.start.row, table.range.end.row)
+            const c1 = Math.min(table.range.start.col, table.range.end.col)
+            const c2 = Math.max(table.range.start.col, table.range.end.col)
+            if (row >= r1 && row <= r2 && col >= c1 && col <= c2) return table
+        }
+        return null
+    }
+
+    getTablesForSheet(sheetId: string): TableDefinition[] {
+        return [...this.tables.values()].filter(t => t.sheetId === sheetId)
+    }
+
+    getAllTables(): TableDefinition[] {
+        return [...this.tables.values()]
+    }
+
+    subscribe(listener: () => void): () => void {
+        this.listeners.add(listener)
+        return () => this.listeners.delete(listener)
+    }
+
+    private _detectHeaders(
+        startRow: number,
+        startCol: number,
+        endCol: number,
+        getCell: (row: number, col: number) => CellData | null,
+    ): boolean {
+        for (let c = startCol; c <= endCol; c++) {
+            const cell = getCell(startRow, c)
+            if (cell?.value !== null && typeof cell?.value !== 'string') return false
+        }
+        return true
+    }
+
+    private _generateName(): string {
+        const names = new Set([...this.tables.values()].map(t => t.name))
+        let n = 1
+        while (names.has(`Table${n}`)) n++
+        return `Table${n}`
+    }
+
+    private _colToLetter(col: number): string {
+        let result = ''
+        let n = col + 1
+        while (n > 0) {
+            const r = (n - 1) % 26
+            result = String.fromCharCode(65 + r) + result
+            n = Math.floor((n - 1) / 26)
+        }
+        return result
+    }
+
+    private _notify(): void {
+        this.listeners.forEach(fn => fn())
+    }
+}
+
+export const tableManager = new TableManager()

--- a/packages/frontend/src/core/table/TableStyleRenderer.ts
+++ b/packages/frontend/src/core/table/TableStyleRenderer.ts
@@ -1,0 +1,136 @@
+import type { CellStyle } from '@cellix/shared'
+import type { TableDefinition } from '@cellix/shared'
+
+interface TableStyleDef {
+    header: { backgroundColor: string; color: string }
+    bandedRow1: { backgroundColor: string }
+    bandedRow2: { backgroundColor?: string }
+    totalRow: { backgroundColor: string }
+}
+
+const TABLE_STYLES: Record<string, TableStyleDef> = {
+    TableStyleLight1: {
+        header: { backgroundColor: '#1167b1', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#deeaf1' },
+        bandedRow2: {},
+        totalRow: { backgroundColor: '#deeaf1' },
+    },
+    TableStyleLight2: {
+        header: { backgroundColor: '#e8700a', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#fce4d6' },
+        bandedRow2: {},
+        totalRow: { backgroundColor: '#fce4d6' },
+    },
+    TableStyleLight3: {
+        header: { backgroundColor: '#70ad47', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#e2efda' },
+        bandedRow2: {},
+        totalRow: { backgroundColor: '#e2efda' },
+    },
+    TableStyleLight4: {
+        header: { backgroundColor: '#ffd966', color: '#000000' },
+        bandedRow1: { backgroundColor: '#fff2cc' },
+        bandedRow2: {},
+        totalRow: { backgroundColor: '#fff2cc' },
+    },
+    TableStyleLight5: {
+        header: { backgroundColor: '#4472c4', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#dae3f3' },
+        bandedRow2: {},
+        totalRow: { backgroundColor: '#dae3f3' },
+    },
+    TableStyleLight6: {
+        header: { backgroundColor: '#e74c3c', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#fce4e4' },
+        bandedRow2: {},
+        totalRow: { backgroundColor: '#fce4e4' },
+    },
+    TableStyleMedium1: {
+        header: { backgroundColor: '#1565c0', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#bbdefb' },
+        bandedRow2: { backgroundColor: '#e3f2fd' },
+        totalRow: { backgroundColor: '#1565c0' },
+    },
+    TableStyleMedium2: {
+        header: { backgroundColor: '#00695c', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#b2dfdb' },
+        bandedRow2: { backgroundColor: '#e0f2f1' },
+        totalRow: { backgroundColor: '#00695c' },
+    },
+    TableStyleMedium3: {
+        header: { backgroundColor: '#4a148c', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#e1bee7' },
+        bandedRow2: { backgroundColor: '#f3e5f5' },
+        totalRow: { backgroundColor: '#4a148c' },
+    },
+    TableStyleMedium4: {
+        header: { backgroundColor: '#37474f', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#cfd8dc' },
+        bandedRow2: { backgroundColor: '#eceff1' },
+        totalRow: { backgroundColor: '#37474f' },
+    },
+    TableStyleDark1: {
+        header: { backgroundColor: '#0d47a1', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#1565c0' },
+        bandedRow2: { backgroundColor: '#1976d2' },
+        totalRow: { backgroundColor: '#0d47a1' },
+    },
+    TableStyleDark2: {
+        header: { backgroundColor: '#1b5e20', color: '#ffffff' },
+        bandedRow1: { backgroundColor: '#2e7d32' },
+        bandedRow2: { backgroundColor: '#388e3c' },
+        totalRow: { backgroundColor: '#1b5e20' },
+    },
+}
+
+const DEFAULT_STYLE = TABLE_STYLES['TableStyleLight1']
+
+export class TableStyleRenderer {
+    static getCellStyleForTable(
+        table: TableDefinition,
+        row: number,
+        col: number,
+    ): Partial<CellStyle> {
+        const styleDef = TABLE_STYLES[table.styleName ?? ''] ?? DEFAULT_STYLE
+
+        const headerRow = table.range.start.row
+        const isHeader = table.showHeaderRow && row === headerRow
+
+        const isTotal = table.showTotalRow && row === table.range.end.row
+
+        const firstDataRow = table.showHeaderRow ? headerRow + 1 : headerRow
+        const dataRowIndex = row - firstDataRow
+
+        if (isHeader) {
+            return {
+                backgroundColor: styleDef.header.backgroundColor,
+                font: { color: styleDef.header.color, weight: 'bold' },
+            }
+        }
+
+        if (isTotal) {
+            return {
+                backgroundColor: styleDef.totalRow.backgroundColor,
+                font: { weight: 'bold' },
+                border: {
+                    top: { style: 'double', color: styleDef.header.backgroundColor },
+                },
+            }
+        }
+
+        if (table.showBandedCols) {
+            const colIndex = col - table.range.start.col
+            const isEven = colIndex % 2 === 0
+            const bg = isEven ? styleDef.bandedRow1.backgroundColor : styleDef.bandedRow2.backgroundColor
+            if (bg) return { backgroundColor: bg }
+        }
+
+        if (table.showBandedRows) {
+            const isEven = dataRowIndex % 2 === 0
+            const bg = isEven ? styleDef.bandedRow1.backgroundColor : styleDef.bandedRow2.backgroundColor
+            if (bg) return { backgroundColor: bg }
+        }
+
+        return {}
+    }
+}

--- a/packages/frontend/src/core/table/index.ts
+++ b/packages/frontend/src/core/table/index.ts
@@ -1,0 +1,2 @@
+export { TableManager, tableManager } from './TableManager'
+export { TableStyleRenderer } from './TableStyleRenderer'

--- a/packages/frontend/src/core/table/index.ts
+++ b/packages/frontend/src/core/table/index.ts
@@ -1,2 +1,3 @@
 export { TableManager, tableManager } from './TableManager'
 export { TableStyleRenderer } from './TableStyleRenderer'
+export { cellRangeToStructuredRef } from './StructuredRefDisplay'

--- a/packages/frontend/src/workers/FormulaEngineClient.ts
+++ b/packages/frontend/src/workers/FormulaEngineClient.ts
@@ -111,6 +111,14 @@ export class FormulaEngineClient {
     return JSON.parse(json) as string[]
   }
 
+  async registerTable(tableJson: string): Promise<void> {
+    await this._send({ type: 'REGISTER_TABLE', tableJson })
+  }
+
+  async unregisterTable(tableId: string): Promise<void> {
+    await this._send({ type: 'UNREGISTER_TABLE', tableId })
+  }
+
   onChanged(listener: Listener): () => void {
     this.listeners.add(listener)
     return () => this.listeners.delete(listener)


### PR DESCRIPTION
## Summary

- **Phase 5-1**: 표(ListObject) 엔진 구현
  - `TableManager` — Ctrl+T로 표 생성, 헤더 자동 감지, 자동 확장, 합계 행 토글, 이름 변경, 열 추가
  - `TableStyleRenderer` — Light/Medium/Dark 12종 표 스타일 (밴딩, 헤더, 합계 행)
  - `GridRenderer` — 표 스타일 렌더링 우선순위 통합 (cfResult > baseStyle > tblStyle) 및 헤더 ▼ 아이콘
  - `FormulaEngineClient` — `registerTable` / `unregisterTable` 추가 (WASM 구조적 참조 연동)
  - `InputManager` — Ctrl+T 단축키 처리 (`setCreateTableCallback`)
  - `GridCanvas` — 표 생성/자동 확장 wiring

- **Phase 5-2**: 구조적 참조 역변환 + 가상 분석 도구
  - `StructuredRefDisplay` — 셀 범위 → `TableName[ColumnName]` 역변환 (수식 바 표시용)
  - `GoalSeekSolver` — 이분법 + 뉴턴-랩슨 혼합 목표값 찾기 (FormulaEngineClient 기반 반복 계산)
  - `ScenarioManager` — 시나리오 저장·전환·요약 보고서 생성
  - `DataTableSolver` — 단변수/이변수 데이터 표 배치 계산
  - `GoalSeekDialog` / `ScenarioDialog` / `DataTableDialog` — React 다이얼로그 UI

## Test plan

- [ ] Ctrl+T로 범위 선택 후 표 생성 → 헤더 감지, 스타일 적용, ▼ 아이콘 표시 확인
- [ ] 표 아래 행에 값 입력 → 자동 확장 확인
- [ ] GoalSeekSolver: A1=변경셀, B1=A1*2 → B1 목표값=10 → A1이 5로 수렴 확인
- [ ] ScenarioManager: 두 시나리오 저장 후 showScenario로 전환 확인
- [ ] DataTableSolver: 단변수 데이터 표 생성 확인
- [ ] `pnpm --filter @cellix/frontend typecheck` — 타입 에러 없음 확인