### PR TITLE
feat: ECharts 차트 및 피벗 테이블 구현 (Phase 6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,3 @@ Thumbs.db
 .vscode/
 *.swp
 *.swo
-
-# Claude Code
-CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1026 @@
+# CLAUDE.md — Cellix 개발 가이드
+
+Claude Code가 이 프로젝트를 작업할 때 반드시 읽고 따라야 하는 기준 문서입니다.
+모든 세션 시작 시 이 파일을 먼저 읽고, 아래 규칙을 엄격히 준수하세요.
+
+---
+
+## 목차
+
+1. [프로젝트 핵심 정보](#1-프로젝트-핵심-정보)
+2. [모노레포 구조](#2-모노레포-구조)
+3. [절대 규칙 (MUST)](#3-절대-규칙-must)
+4. [패키지별 개발 규칙](#4-패키지별-개발-규칙)
+5. [타입 시스템](#5-타입-시스템)
+6. [Canvas 그리드 엔진 규칙](#6-canvas-그리드-엔진-규칙)
+7. [Rust/WASM 엔진 규칙](#7-rustwasm-엔진-규칙)
+8. [상태 관리 규칙](#8-상태-관리-규칙)
+9. [백엔드 규칙](#9-백엔드-규칙)
+10. [명명 규칙](#10-명명-규칙)
+11. [에러 처리 규칙](#11-에러-처리-규칙)
+12. [파일 참조 가이드](#12-파일-참조-가이드)
+13. [검증 체크리스트](#13-검증-체크리스트)
+14. [현재 개발 상태](#14-현재-개발-상태)
+
+---
+
+## 1. 프로젝트 핵심 정보
+
+```
+프로젝트명:   cellix
+패키지 매니저: pnpm (workspaces)
+Node.js:      >= 20.0.0
+TypeScript:   5.x (strict mode)
+언어:         TypeScript (프론트/백), Rust (수식 엔진)
+```
+
+**패키지 이름 (package.json name 필드):**
+
+```
+@cellix/shared        # packages/shared
+@cellix/frontend      # packages/frontend
+@cellix/backend       # packages/backend
+formula-engine        # packages/formula-engine (Rust crate)
+```
+
+**포트 기본값:**
+
+```
+프론트엔드:  5173
+백엔드:     3001
+PostgreSQL: 5432
+Redis:      6379
+```
+
+---
+
+## 2. 모노레포 구조
+
+```
+cellix/
+├── packages/
+│   ├── shared/           # @cellix/shared — 공유 타입, 유틸
+│   ├── frontend/         # @cellix/frontend — React + Canvas
+│   ├── backend/          # @cellix/backend — Fastify API
+│   └── formula-engine/   # Rust/WASM 수식 계산 엔진
+├── infra/
+│   └── nginx/            # Nginx 설정 (프로덕션 전용)
+├── docker-compose.yml        # 개발용
+├── docker-compose.prod.yml   # 프로덕션용
+├── Makefile
+├── package.json              # 루트 (workspaces 설정)
+├── pnpm-workspace.yaml
+├── tsconfig.base.json
+├── .env.example
+├── README.md
+└── CLAUDE.md                 # 이 파일
+```
+
+**패키지 의존 관계:**
+
+```
+frontend  ──depends──▶  shared
+backend   ──depends──▶  shared
+frontend  ──런타임────▶  formula-engine/pkg (WASM)
+```
+
+---
+
+## 3. 절대 규칙 (MUST)
+
+### 3-1. 작업 시작 전 파일 읽기
+
+모든 세션에서 작업 대상 파일을 **반드시** 먼저 읽은 후 수정하세요.
+지시문에 `[현재 프로젝트 파악 — 작업 시작 전 반드시 읽을 파일들]` 섹션이 있으면
+그 파일들을 전부 읽고 나서 코드를 작성하세요.
+
+```bash
+# 세션 시작 시 항상 확인할 것
+cat packages/shared/src/types/cell.ts
+cat packages/shared/src/types/sheet.ts
+```
+
+### 3-2. 타입 공유 — shared 패키지 최우선
+
+- 두 패키지 이상에서 사용하는 타입은 **반드시** `packages/shared/src/types/` 에 정의
+- 절대로 각 패키지 내부에 중복 타입을 만들지 마세요
+- `@cellix/shared` import 경로를 사용하세요
+
+```typescript
+// ✅ 올바름
+import type { CellData, CellStyle } from "@cellix/shared";
+
+// ❌ 금지
+import type { CellData } from "../../shared/src/types/cell";
+```
+
+### 3-3. DOM으로 스프레드시트 셀 렌더링 금지
+
+스프레드시트 그리드 셀은 **Canvas에서만** 렌더링합니다.
+React 컴포넌트(`<div>`, `<table>`, `<span>` 등)로 셀을 직접 렌더링하는 코드를 작성하지 마세요.
+
+```typescript
+// ✅ 올바름 — Canvas에 그리기
+ctx.fillText(cellValue, x + 4, y + h / 2)
+
+// ❌ 금지 — DOM으로 셀 렌더링
+return <div className="cell">{cellValue}</div>
+```
+
+### 3-4. pnpm만 사용
+
+패키지 설치는 반드시 `pnpm`을 사용합니다. `npm install` 또는 `yarn` 사용 금지.
+
+```bash
+# ✅ 올바름
+pnpm add zustand
+pnpm --filter @cellix/frontend add echarts
+
+# ❌ 금지
+npm install zustand
+```
+
+### 3-5. 환경 변수는 env.ts를 통해서만
+
+백엔드에서 `process.env.xxx` 직접 접근 금지.
+반드시 `packages/backend/src/config/env.ts`의 `env` 객체를 통해 접근하세요.
+
+```typescript
+// ✅ 올바름
+import { env } from "../config/env";
+const port = env.PORT;
+
+// ❌ 금지
+const port = process.env.PORT;
+```
+
+### 3-6. Map 타입 JSON 직렬화
+
+`WorkbookData`, `SheetData`의 `Map` 필드는 `JSON.stringify`로 직렬화되지 않습니다.
+API 전송 시 반드시 `packages/shared/src/utils/workbook-serializer.ts`의 변환 함수를 사용하세요.
+
+```typescript
+// ✅ 올바름
+import { serializeWorkbook, deserializeWorkbook } from "@cellix/shared";
+const json = serializeWorkbook(workbookData);
+
+// ❌ 금지 (Map이 {}로 직렬화됨)
+const json = JSON.stringify(workbookData);
+```
+
+### 3-7. WASM 빌드 후 테스트
+
+`packages/formula-engine/src/` 의 Rust 코드를 수정한 경우,
+반드시 다음 순서로 검증하세요:
+
+```bash
+cd packages/formula-engine
+cargo test            # 1. 단위 테스트
+wasm-pack build --target web --out-dir pkg --dev  # 2. WASM 빌드
+```
+
+빌드 에러가 있으면 해결 후 다음 단계로 넘어가세요.
+
+---
+
+## 4. 패키지별 개발 규칙
+
+### 4-1. packages/shared
+
+- **순수 타입과 순수 유틸만** — 외부 의존성(React, Fastify 등) 절대 import 금지
+- 새 타입 추가 시 `src/types/index.ts`에서 반드시 export
+- `Map` 관련 직렬화 유틸은 `src/utils/workbook-serializer.ts`에
+
+**파일별 역할:**
+
+```
+types/cell.ts       — CellData, CellStyle, CellAddress, CellRange, MergeInfo
+types/sheet.ts      — SheetData, WorkbookData, ColumnMeta, RowMeta
+types/table.ts      — TableDefinition, TableColumn, TableStyleName
+types/formula.ts    — FormulaToken, ParsedFormula
+types/exam.ts       — ExamProblem, SubmissionResult, GradingRule
+types/api.ts        — ApiResponse<T>
+utils/index.ts      — assert 등 기본 유틸
+utils/workbook-serializer.ts — Map ↔ JSON 변환
+```
+
+### 4-2. packages/formula-engine (Rust)
+
+- `src/lib.rs` — WASM 바인딩만. 비즈니스 로직 없음
+- `src/parser/` — 순수 파싱. IO, 상태 없음
+- `src/evaluator/` — 순수 계산. `EvalContext` trait을 통해서만 셀 데이터 접근
+- `src/engine/` — 상태 보유. `Workbook`, `DependencyGraph`, `Engine`
+- JS와의 모든 데이터 교환은 **JSON 문자열**로 직렬화 (`wasm_bindgen`이 복잡한 타입 미지원)
+- `#[wasm_bindgen]` 함수는 `pub fn`, 파라미터는 `&str` 또는 원시 타입만
+- 에러는 패닉 대신 `Result<_, String>` 로 처리 (WASM에서 패닉 = 크래시)
+
+```rust
+// ✅ 올바름
+#[wasm_bindgen]
+pub fn set_cell(&mut self, sheet_id: &str, row: u32, col: u32, data_json: &str) -> String {
+    let data: JsCellData = serde_json::from_str(data_json)
+        .unwrap_or_default();
+    let changed = self.inner.set_cell(sheet_id, row, col, data);
+    serde_json::to_string(&changed).unwrap_or_default()
+}
+
+// ❌ 금지 — 복잡한 타입을 직접 WASM 경계에 노출
+#[wasm_bindgen]
+pub fn set_cell(&mut self, data: JsCellData) -> Vec<ChangedCell> { ... }
+```
+
+### 4-3. packages/frontend
+
+**디렉토리 역할:**
+
+```
+core/renderer/    — Canvas 렌더링 로직만. React 없음
+core/viewport/    — 스크롤, 좌표 변환. React 없음
+core/selection/   — 선택 상태 관리. React 없음
+core/input/       — 키보드/마우스 처리. React 없음
+core/history/     — Undo/Redo, 클립보드. React 없음
+core/style/       — 셀 스타일 관리. React 없음
+core/table/       — 표(Ctrl+T) 관리. React 없음
+core/chart/       — 차트 정의/관리. React 없음
+core/pivot/       — 피벗 테이블 계산. React 없음
+core/analysis/    — 가상 분석 도구. React 없음
+core/data/        — 정렬/필터/유효성. React 없음
+core/formula/     — DirtyCellTracker. React 없음
+core/io/          — XLSX 가져오기/내보내기. React 없음
+workers/          — Web Worker 파일들
+components/       — React 컴포넌트 (Canvas 바깥 UI만)
+pages/            — React 페이지 컴포넌트
+store/            — Zustand 스토어
+api/              — API 클라이언트
+```
+
+**React 컴포넌트와 Canvas 엔진의 책임 분리:**
+
+```
+React 컴포넌트 담당:
+  - Toolbar, FormulaBar, SheetTabs (Canvas 바깥 UI)
+  - 다이얼로그, 모달, 드롭다운
+  - 페이지 라우팅
+  - 사용자 인증 UI
+
+Canvas 엔진 담당:
+  - 셀 렌더링 (격자선, 텍스트, 배경, 테두리)
+  - 선택 영역 하이라이트
+  - 필터 아이콘, 채우기 핸들
+  - 차트 오버레이 (ChartOverlay: Canvas 위 absolute div)
+```
+
+### 4-4. packages/backend
+
+**디렉토리 역할:**
+
+```
+config/env.ts      — Zod 환경변수 검증 (유일한 env 접근 포인트)
+db/schema.ts       — Drizzle 테이블 정의 (스키마 변경 시 migration 생성 필수)
+db/index.ts        — DB 연결 싱글톤
+plugins/           — Fastify 플러그인 (fastify-plugin으로 래핑)
+routes/            — 라우트 핸들러 (비즈니스 로직 최소화)
+services/          — 비즈니스 로직 (grading, auth 등)
+middleware/        — preHandler 함수들
+```
+
+---
+
+## 5. 타입 시스템
+
+### 핵심 타입 정의 위치
+
+| 타입               | 파일                                |
+| ------------------ | ----------------------------------- |
+| `CellData`         | `@cellix/shared` → `types/cell.ts`  |
+| `CellStyle`        | `@cellix/shared` → `types/cell.ts`  |
+| `CellAddress`      | `@cellix/shared` → `types/cell.ts`  |
+| `CellRange`        | `@cellix/shared` → `types/cell.ts`  |
+| `CellValue`        | `@cellix/shared` → `types/cell.ts`  |
+| `SheetData`        | `@cellix/shared` → `types/sheet.ts` |
+| `WorkbookData`     | `@cellix/shared` → `types/sheet.ts` |
+| `TableDefinition`  | `@cellix/shared` → `types/table.ts` |
+| `ExamProblem`      | `@cellix/shared` → `types/exam.ts`  |
+| `SubmissionResult` | `@cellix/shared` → `types/exam.ts`  |
+| `ApiResponse<T>`   | `@cellix/shared` → `types/api.ts`   |
+
+### CellKey 형식
+
+셀을 Map의 키로 사용할 때 형식:
+
+```typescript
+// SheetData.cells의 키: "{row}:{col}" (0-based)
+const key: CellKey = `${row}:${col}`;
+
+// WorkbookStore의 cells Record 키: "{sheetId}:{row}:{col}"
+const key = `${sheetId}:${row}:${col}`;
+
+// WASM 엔진 ChangedCell의 키: (sheet_id, row, col) — 별도 필드
+```
+
+### CellValue 타입
+
+```typescript
+type CellValue = string | number | boolean | null;
+// null = 빈 셀
+// string으로 시작하는 수식은 formula 필드에, value는 계산 결과
+```
+
+---
+
+## 6. Canvas 그리드 엔진 규칙
+
+### 렌더 루프 구조
+
+```typescript
+// GridCanvas.tsx의 renderLoop 구조
+const renderLoop = () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    gridRenderer.draw(ctx); // 1. 배경 + 셀 + 격자선
+    selectionRenderer.markDirty();
+    selectionRenderer.drawSelections(ctx, selections, activeCell); // 2. 선택 영역
+    // 잘라내기 테두리 등 오버레이  // 3. 기타 오버레이
+
+    rafId = requestAnimationFrame(renderLoop);
+};
+```
+
+### ViewportManager 사용법
+
+```typescript
+// 셀 → 픽셀 (Canvas 좌표)
+const { x, y } = viewport.cellToPixel(row, col)
+
+// 픽셀 → 셀 (마우스 클릭 처리)
+const { row, col } = viewport.pixelToCell(mouseX, mouseY)
+
+// 보이는 범위 순회 (렌더링 루프에서)
+viewport.iterateRows((row, y, height) => { ... })
+viewport.iterateCols((col, x, width) => { ... })
+
+// 셀 크기
+const h = viewport.getRowHeight(row)
+const w = viewport.getColWidth(col)
+```
+
+### 성능 규칙
+
+- `iterateRows` / `iterateCols` 로 보이는 셀만 처리 — `getOffset`을 매 셀마다 호출하지 말 것
+- `requestAnimationFrame`에서만 Canvas draw 호출
+- `mousemove` 이벤트는 직접 처리 금지 — RAF로 쓰로틀링
+- dirty 플래그 패턴: 변경이 없으면 re-draw 건너뜀
+
+```typescript
+// ✅ 올바름 — RAF 쓰로틀링
+let pendingX = 0,
+    pendingY = 0,
+    rafId: number | null = null;
+canvas.addEventListener("mousemove", (e) => {
+    pendingX = e.offsetX;
+    pendingY = e.offsetY;
+    if (rafId !== null) return;
+    rafId = requestAnimationFrame(() => {
+        rafId = null;
+        processMouseMove(pendingX, pendingY);
+    });
+});
+
+// ❌ 금지 — mousemove마다 즉시 처리
+canvas.addEventListener("mousemove", (e) => {
+    processMouseMove(e.offsetX, e.offsetY);
+    draw();
+});
+```
+
+### SizeStore 사용
+
+행/열 크기는 `Uint16Array` 기반 `SizeStore`에 저장됩니다.
+
+```typescript
+// ✅ 올바름
+viewport.setRowHeight(row, 40); // 행 높이 설정
+viewport.setColWidth(col, 120); // 열 너비 설정
+
+// ❌ 금지 — SizeStore.data에 직접 접근
+viewport.rows.data[row] = 40;
+```
+
+---
+
+## 7. Rust/WASM 엔진 규칙
+
+### 아키텍처
+
+```
+FormulaEngineClient (TypeScript, 메인 스레드)
+    ↓ postMessage (JSON)
+formula.worker.ts (Web Worker)
+    ↓ import
+formula_engine.js (wasm-bindgen 생성)
+    ↓ 호출
+formula_engine_bg.wasm (Rust 컴파일)
+```
+
+### FormulaEngineClient 사용
+
+```typescript
+import { formulaEngine } from "../workers";
+
+// 초기화 (앱 시작 시 1회)
+await formulaEngine.initialize();
+
+// 셀 설정 — 반환값: 재계산된 셀 목록
+const changed = await formulaEngine.setCell(sheetId, row, col, value, formula);
+
+// 배치 업데이트 (성능상 여러 셀을 한번에)
+const changed = await formulaEngine.batchSet([
+    { sheetId, row: 0, col: 0, value: 100 },
+    { sheetId, row: 1, col: 0, value: 200 },
+]);
+
+// 수식 참조 파싱 (색깔 하이라이트용)
+const refs = await formulaEngine.parseRefs("=SUM(A1:A10)+B5");
+// → ['A1:A10', 'B5']
+```
+
+### WASM CellVal 타입
+
+```typescript
+// Worker에서 반환되는 셀 값 타입
+interface CellValResult {
+    t: "n" | "s" | "b" | "e" | "nil";
+    // n=number, s=string, b=boolean, e=error("#DIV/0!" 등), nil=null
+    v?: number | string | boolean;
+}
+```
+
+### 구조적 참조
+
+표 생성 시 WASM 엔진에 반드시 등록해야 구조적 참조가 동작합니다:
+
+```typescript
+await formulaEngine.registerTable(
+    JSON.stringify({
+        id: table.id,
+        name: table.name,
+        sheet_id: table.sheetId,
+        start_row: table.range.start.row,
+        start_col: table.range.start.col,
+        end_row: table.range.end.row,
+        end_col: table.range.end.col,
+        has_header: table.showHeaderRow,
+        has_total: table.showTotalRow,
+        columns: table.columns.map((c) => c.name),
+    }),
+);
+```
+
+---
+
+## 8. 상태 관리 규칙
+
+### Zustand 스토어 구조
+
+```
+useWorkbookStore — 워크북 데이터 (셀, 시트 목록, 계산값 캐시)
+useUIStore       — UI 상태 (선택, 편집 모드, 히스토리, 활성 셀 데이터)
+useAuthStore     — 인증 상태 (유저 정보, 토큰)
+```
+
+### 셀 데이터 흐름
+
+```
+사용자 입력
+    ↓
+InputManager._commitEdit()
+    ↓
+useWorkbookStore.setCell()  ← Zustand 즉시 업데이트 (동기)
+    ↓ (비동기, 백그라운드)
+formulaEngine.setCell()     ← WASM 엔진 업데이트
+    ↓ (onChanged 이벤트)
+useWorkbookStore.setCalculatedValues()  ← 계산값 캐시 업데이트
+    ↓
+GridRenderer.draw()         ← calculatedValues 우선 표시
+```
+
+### 스토어 셀렉터 사용
+
+```typescript
+// ✅ 올바름 — 필요한 상태만 구독
+const activeCell = useUIStore((state) => state.activeCell);
+const canUndo = useUIStore((state) => state.canUndo);
+
+// ❌ 성능 저하 — 전체 스토어 구독
+const store = useUIStore();
+```
+
+### Canvas 엔진과 스토어 연결 방법
+
+Canvas 엔진 클래스들은 React를 import하지 않습니다.
+`GridCanvas.tsx`에서 엔진 인스턴스의 이벤트를 구독하여 Zustand에 push합니다.
+
+```typescript
+// GridCanvas.tsx에서
+const unsubSelection = selection.subscribe((state: SelectionState) => {
+    useUIStore.getState().setSelectionState(state); // Zustand에 push
+});
+```
+
+---
+
+## 9. 백엔드 규칙
+
+### 라우트 핸들러 구조
+
+```typescript
+// routes/*.routes.ts 패턴
+export const problemRoutes: FastifyPluginAsync = async (app) => {
+    app.get(
+        "/",
+        {
+            preHandler: [app.authenticate], // 인증 필요 시
+            schema: {
+                querystring: GetProblemsQuerySchema,
+                response: { 200: GetProblemsResponseSchema },
+            },
+        },
+        async (request, reply) => {
+            // 비즈니스 로직은 services/로 위임
+            const result = await problemService.getAll(request.query);
+            return { success: true, data: result };
+        },
+    );
+};
+```
+
+### API 응답 형식
+
+**성공:**
+
+```typescript
+{ success: true, data: T }
+// 또는 페이지네이션
+{ success: true, data: T[], total: number, page: number }
+```
+
+**실패:**
+
+```typescript
+{ success: false, error: string, code: string }
+// code: 'UNAUTHORIZED' | 'FORBIDDEN' | 'NOT_FOUND' | 'CONFLICT' |
+//       'VALIDATION_ERROR' | 'INTERNAL_ERROR'
+```
+
+### 채점 서비스 규칙
+
+```typescript
+// grading.service.ts
+// - HyperFormula는 백엔드에서만 사용 (프론트는 WASM)
+// - answerWorkbook은 절대로 API 응답에 포함시키지 말 것
+// - gradingConfig도 학생에게 노출 금지
+```
+
+### DB 스키마 변경 절차
+
+```bash
+# 1. schema.ts 수정
+# 2. 마이그레이션 파일 생성
+pnpm --filter @cellix/backend db:generate
+
+# 3. 마이그레이션 적용
+pnpm --filter @cellix/backend db:migrate
+
+# ❌ 금지 — 마이그레이션 없이 스키마만 바꾸는 것
+```
+
+---
+
+## 10. 명명 규칙
+
+### TypeScript
+
+```typescript
+// 클래스: PascalCase
+class ViewportManager {}
+class SelectionManager {}
+
+// 인터페이스: PascalCase (I 접두사 없음)
+interface CellData {}
+interface SelectionRange {}
+
+// 타입 별칭: PascalCase
+type CellValue = string | number | boolean | null
+type CellKey = string
+
+// 함수/변수: camelCase
+const viewportManager = new ViewportManager()
+function cellToPixel(row: number, col: number): PixelPoint {}
+
+// 상수: UPPER_SNAKE_CASE
+const MAX_ROWS = 1_048_576
+const DEFAULT_ROW_HEIGHT = 20
+const RANGE_COLORS = ['#4B87FF', '#00CC66', ...]
+
+// 파일명: PascalCase (클래스), camelCase (유틸/훅)
+// ViewportManager.ts, useWorkbookStore.ts, cellUtils.ts
+
+// Zustand 스토어 훅: use + PascalCase + Store
+const useWorkbookStore = create<WorkbookState>(...)
+```
+
+### Rust
+
+```rust
+// 구조체/열거형: PascalCase
+pub struct FormulaEngine {}
+pub enum CellVal {}
+
+// 함수/메서드: snake_case
+pub fn set_cell(&mut self, ...) {}
+fn parse_col_name(&self, s: &str) -> Option<u32> {}
+
+// 상수: UPPER_SNAKE_CASE
+const MAX_ITERATIONS: u32 = 1000;
+
+// WASM 노출 함수: snake_case (JS 측에서 camelCase로 접근)
+#[wasm_bindgen]
+pub fn set_cell(...) {}  // JS: engine.set_cell()
+```
+
+### CSS / 스타일
+
+인라인 스타일 객체를 사용합니다 (CSS 파일 최소화).
+
+```typescript
+// ✅ 올바름
+const style: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    borderBottom: "1px solid #dadce0",
+};
+
+// ❌ 지양 (별도 CSS 파일)
+// .toolbar { display: flex; }
+```
+
+---
+
+## 11. 에러 처리 규칙
+
+### TypeScript (프론트)
+
+```typescript
+// 비동기 작업은 try-catch
+try {
+  const changed = await formulaEngine.setCell(...)
+} catch (err) {
+  console.error('[FormulaEngine] setCell failed:', err)
+  // UI에 에러 표시 (토스트 등)
+}
+
+// Worker 타임아웃 처리됨 (FormulaEngineClient 내부)
+// — 10초 초과 시 자동으로 reject
+```
+
+### TypeScript (백엔드)
+
+```typescript
+// Fastify 에러 핸들러 (app.ts에서 설정)
+app.setErrorHandler((error, request, reply) => {
+    if (error instanceof ZodError) {
+        return reply.status(422).send({
+            success: false,
+            error: error.errors[0].message,
+            code: "VALIDATION_ERROR",
+        });
+    }
+    app.log.error(error);
+    return reply.status(500).send({
+        success: false,
+        error: "Internal server error",
+        code: "INTERNAL_ERROR",
+    });
+});
+```
+
+### Rust
+
+```rust
+// ✅ 올바름 — Result로 에러 전파
+fn parse_number(s: &str) -> Result<f64, String> {
+    s.parse::<f64>().map_err(|e| format!("숫자 파싱 실패: {}", e))
+}
+
+// WASM 경계에서 에러 문자열 반환
+#[wasm_bindgen]
+pub fn set_cell(...) -> String {
+    match self.inner.set_cell(...) {
+        Ok(changed) => serde_json::to_string(&changed).unwrap_or_default(),
+        Err(e) => format!("{{\"error\":\"{}\"}}", e),
+    }
+}
+
+// ❌ 금지 — WASM에서 패닉 사용
+fn parse_number(s: &str) -> f64 {
+    s.parse().expect("파싱 실패")  // WASM에서 패닉 = 크래시
+}
+```
+
+---
+
+## 12. 파일 참조 가이드
+
+새 기능 작업 시 참조해야 할 핵심 파일들입니다.
+
+### Canvas 렌더링 관련
+
+```
+packages/frontend/src/core/renderer/GridRenderer.ts    — 셀 그리기 로직
+packages/frontend/src/core/viewport/ViewportManager.ts — 좌표 변환, 가상 스크롤
+packages/frontend/src/core/viewport/SizeStore.ts       — 행/열 크기 저장
+packages/frontend/src/components/GridCanvas.tsx        — 엔진 통합 포인트
+```
+
+### 선택/입력 관련
+
+```
+packages/frontend/src/core/selection/SelectionManager.ts   — 선택 상태
+packages/frontend/src/core/selection/SelectionRenderer.ts  — 선택 그리기
+packages/frontend/src/core/input/InputManager.ts           — 키/마우스 처리
+packages/frontend/src/core/history/HistoryManager.ts       — Undo/Redo
+packages/frontend/src/core/history/ClipboardManager.ts     — 복사/붙여넣기
+```
+
+### 수식 엔진 관련
+
+```
+packages/formula-engine/src/lib.rs                — WASM 바인딩
+packages/formula-engine/src/parser/mod.rs         — 파서
+packages/formula-engine/src/parser/tokenizer.rs   — 토크나이저
+packages/formula-engine/src/parser/ast.rs         — AST 정의
+packages/formula-engine/src/evaluator/mod.rs      — 평가기
+packages/formula-engine/src/engine/mod.rs         — 메인 엔진
+packages/frontend/src/workers/formula.worker.ts   — Web Worker
+packages/frontend/src/workers/FormulaEngineClient.ts — TS 클라이언트
+```
+
+### 스타일/서식 관련
+
+```
+packages/shared/src/types/cell.ts                      — CellStyle 타입
+packages/frontend/src/core/style/StyleManager.ts       — 스타일 관리
+packages/frontend/src/core/style/NumberFormatter.ts    — 숫자 포맷
+packages/frontend/src/core/conditional/               — 조건부 서식
+```
+
+### 표(Table) 관련
+
+```
+packages/shared/src/types/table.ts                     — TableDefinition 타입
+packages/frontend/src/core/table/TableManager.ts       — 표 CRUD
+packages/frontend/src/core/table/TableStyleRenderer.ts — 표 스타일 렌더링
+packages/formula-engine/src/engine/table.rs            — 구조적 참조 해석
+```
+
+### 상태 관리 관련
+
+```
+packages/frontend/src/store/useWorkbookStore.ts  — 워크북 데이터
+packages/frontend/src/store/useUIStore.ts        — UI 상태
+packages/frontend/src/store/useAuthStore.ts      — 인증 상태
+```
+
+### 백엔드 관련
+
+```
+packages/backend/src/db/schema.ts              — DB 테이블 정의
+packages/backend/src/config/env.ts             — 환경변수
+packages/backend/src/app.ts                    — Fastify 앱 설정
+packages/backend/src/services/grading.service.ts — 채점 로직
+packages/shared/src/types/exam.ts              — ExamProblem, SubmissionResult
+```
+
+### 공유 타입 관련
+
+```
+packages/shared/src/types/cell.ts     — 셀 관련 핵심 타입
+packages/shared/src/types/sheet.ts    — 시트/워크북 타입
+packages/shared/src/types/exam.ts     — 문제/제출 타입
+packages/shared/src/types/api.ts      — API 응답 타입
+packages/shared/src/utils/workbook-serializer.ts — Map 직렬화
+```
+
+---
+
+## 13. 검증 체크리스트
+
+각 명령어 완료 후 다음 항목을 확인하세요.
+
+### TypeScript 검증
+
+```bash
+# 타입 에러 확인 (에러 없어야 함)
+pnpm typecheck
+
+# 또는 패키지별
+pnpm --filter @cellix/shared typecheck
+pnpm --filter @cellix/frontend typecheck
+pnpm --filter @cellix/backend typecheck
+```
+
+### Rust 검증
+
+```bash
+cd packages/formula-engine
+
+# 단위 테스트 실행
+cargo test 2>&1 | tail -20
+
+# WASM 빌드 (에러 없어야 함)
+wasm-pack build --target web --out-dir pkg --dev 2>&1 | tail -20
+```
+
+### 런타임 검증
+
+```bash
+# 개발 서버 실행
+docker compose up -d postgres redis
+pnpm build:wasm:dev
+pnpm dev
+
+# 브라우저에서 확인할 항목:
+# 1. http://localhost:5173 접속 → 스프레드시트 표시
+# 2. 셀 클릭 → 선택 하이라이트
+# 3. 숫자 입력 → Enter → 다음 셀 이동 + 값 표시
+# 4. =1+2 입력 → Enter → 3 표시
+# 5. A1=5 입력, B1=A1*2 입력 → B1에 10 표시
+# 6. A1 값 변경 → B1 자동 업데이트
+# 7. 콘솔 에러 없음
+```
+
+### API 검증
+
+```bash
+# 백엔드 헬스 체크
+curl http://localhost:3001/api/health
+
+# 회원가입
+curl -X POST http://localhost:3001/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@test.com","password":"testpassword1","name":"테스터"}'
+
+# 로그인
+curl -X POST http://localhost:3001/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@test.com","password":"testpassword1"}'
+```
+
+---
+
+## 14. 현재 개발 상태
+
+### 완료된 Phase
+
+| Phase   | 내용                             | 상태    |
+| ------- | -------------------------------- | ------- |
+| Phase 1 | 모노레포 설정, 공유 타입, Docker | ✅ 완료 |
+| Phase 2 | Canvas 그리드 엔진, React 쉘     | ✅ 완료 |
+
+**Phase 2 완료 목록:**
+
+- `ViewportManager` — 가상 스크롤, 좌표 변환, `SizeStore` (Uint16Array)
+- `SelectionManager` — 단일/범위/다중 선택, Ctrl+클릭, 수식 참조 색깔
+- `SelectionRenderer` — Canvas 선택 영역 그리기
+- `InputManager` — IME 오버레이, 편집 모드, 드래그 채우기, RAF 쓰로틀링
+- `GridRenderer` — Canvas 격자선, 셀 텍스트 렌더링
+- `HistoryManager` — Command 패턴, Undo/Redo, 배치 커맨드
+- `ClipboardManager` — Ctrl+C/X/V, TSV 직렬화, 선택하여 붙여넣기
+- `SpreadsheetShell`, `GridCanvas`, `Toolbar`, `FormulaBar`, `SheetTabs`
+- `useWorkbookStore`, `useUIStore`
+- Fastify 기본 서버 (`/api/health`)
+
+### 진행 예정 Phase
+
+| Phase   | 내용                               | 상태      |
+| ------- | ---------------------------------- | --------- |
+| Phase 3 | Rust/WASM 수식 엔진                | 🔲 미완료 |
+| Phase 4 | 셀 서식, 정렬, 필터, 유효성 검사   | 🔲 미완료 |
+| Phase 5 | 표(Ctrl+T), 구조적 참조, 가상 분석 | 🔲 미완료 |
+| Phase 6 | 차트(ECharts), 피벗 테이블         | 🔲 미완료 |
+| Phase 7 | 백엔드 API, DB 스키마, 인증        | 🔲 미완료 |
+| Phase 8 | 채점 엔진, 문제 풀이 UI            | 🔲 미완료 |
+| Phase 9 | 성능 최적화, Nginx, 프로덕션 배포  | 🔲 미완료 |
+
+### 알려진 버그 및 TODO
+
+1. **[수정 필요]** `packages/frontend/vite.config.ts` — proxy 타겟이 `localhost:3000`으로 잘못 설정됨 → `localhost:3001`로 수정 필요
+2. **[TODO]** `InputManager._commitEdit()` — `// TODO: cell data store 연동` 주석 → Phase 3-5에서 완성
+3. **[TODO]** `Toolbar.tsx` — 모든 버튼이 껍데기만 있음 → Phase 4-1에서 실제 기능 연결
+4. **[TODO]** `GridRenderer.ts` — 스타일/조건부 서식 미적용 → Phase 4에서 통합
+
+---
+
+## 부록 A: 자주 실수하는 패턴
+
+### A-1. Map 직렬화 실수
+
+```typescript
+// ❌ 실수 — Map이 {} 로 직렬화됨
+const body = JSON.stringify(workbookData);
+await fetch("/api/submissions", { body });
+
+// ✅ 올바름
+import { serializeWorkbook } from "@cellix/shared";
+const body = JSON.stringify(serializeWorkbook(workbookData));
+```
+
+### A-2. WASM 초기화 순서 실수
+
+```typescript
+// ❌ 실수 — 초기화 전에 사용
+formulaEngine.setCell(...)  // Error: Engine not initialized
+
+// ✅ 올바름 — 앱 시작 시 먼저 초기화
+await formulaEngine.initialize()
+await formulaEngine.addSheet(firstSheetId, 'Sheet1')
+// 이후 setCell 사용 가능
+```
+
+### A-3. React 컴포넌트에서 Canvas 직접 접근 실수
+
+```typescript
+// ❌ 실수 — 매 렌더마다 새 인스턴스 생성
+function GridCanvas() {
+  const renderer = new GridRenderer(...)  // 매 렌더마다 생성됨!
+  return <canvas />
+}
+
+// ✅ 올바름 — useEffect + useRef
+function GridCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  useEffect(() => {
+    const renderer = new GridRenderer(...)  // 마운트 시 1회만
+    return () => renderer.destroy()
+  }, [])
+  return <canvas ref={canvasRef} />
+}
+```
+
+### A-4. 행/열 인덱스 혼동
+
+```typescript
+// Cellix의 모든 인덱스는 0-based
+// row=0, col=0 → A1 셀
+// row=0, col=1 → B1 셀
+
+// CellKey 형식: "{row}:{col}" (0-based)
+const key = `${row}:${col}`; // ✅ "0:0" for A1
+
+// 사용자에게 표시할 때만 +1
+const displayRow = row + 1; // ✅ "1" for row=0
+const displayCol = colToLetter(col); // ✅ "A" for col=0
+```
+
+### A-5. Rust에서 0-based vs 1-based
+
+```rust
+// 파서에서 셀 참조는 0-based로 변환하여 저장
+// "A1" → CellRef { row: 0, col: 0 }
+// "B2" → CellRef { row: 1, col: 1 }
+
+fn parse_row_num(s: &str) -> Option<u32> {
+    s.parse::<u32>().ok().map(|n| n - 1)  // ✅ 1-based 입력 → 0-based 저장
+}
+```
+
+---
+
+## 부록 B: 유용한 개발 명령어
+
+```bash
+# 전체 개발 서버 (WASM 빌드 포함)
+pnpm build:wasm:dev && pnpm dev
+
+# 특정 패키지만 타입 체크
+pnpm --filter @cellix/frontend typecheck
+
+# WASM 테스트 + 빌드 (Rust 변경 후)
+cd packages/formula-engine && cargo test && wasm-pack build --target web --out-dir pkg --dev
+
+# DB 초기화 (개발 중 스키마 망가진 경우)
+docker compose down -v && docker compose up -d postgres redis
+pnpm --filter @cellix/backend db:migrate
+
+# 의존성 전체 재설치
+pnpm clean && pnpm install
+
+# 특정 패키지에 의존성 추가
+pnpm --filter @cellix/frontend add react-router-dom
+pnpm --filter @cellix/frontend add -D @types/node
+
+# Drizzle Studio (DB 시각화)
+docker compose up -d postgres
+pnpm --filter @cellix/backend db:studio
+# → http://local.drizzle.studio 에서 확인
+```

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@cellix/shared": "workspace:*",
+        "echarts": "^6.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "zustand": "^5.0.12"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,6 +13,9 @@
     },
     "dependencies": {
         "@cellix/shared": "workspace:*",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "echarts": "^6.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/packages/frontend/src/components/ChartOverlay.tsx
+++ b/packages/frontend/src/components/ChartOverlay.tsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react'
+import * as echarts from 'echarts'
+import type { CellData } from '@cellix/shared'
+import type { ViewportManager } from '../core/viewport'
+import type { ChartDefinition } from '../core/chart/types'
+import { chartManager, buildEChartsOption } from '../core/chart'
+
+// ── 위치 계산 ─────────────────────────────────────────────────────────────────
+
+interface ChartPos {
+    x: number
+    y: number
+    width: number
+    height: number
+}
+
+function calcPos(chart: ChartDefinition, vp: ViewportManager): ChartPos {
+    const { x, y } = vp.cellToPixel(chart.anchorRow, chart.anchorCol)
+    let width = 0
+    for (let c = chart.anchorCol; c < chart.anchorCol + chart.widthCols; c++) {
+        width += vp.getColWidth(c)
+    }
+    let height = 0
+    for (let r = chart.anchorRow; r < chart.anchorRow + chart.heightRows; r++) {
+        height += vp.getRowHeight(r)
+    }
+    return { x, y, width: Math.max(80, width), height: Math.max(60, height) }
+}
+
+// ── 개별 차트 아이템 ──────────────────────────────────────────────────────────
+
+interface ChartItemProps {
+    chart: ChartDefinition
+    pos: ChartPos
+    viewport: ViewportManager
+    getCell: (sheetId: string, row: number, col: number) => CellData | null
+    isSelected: boolean
+    onSelect: () => void
+    dataVersion: number
+}
+
+function ChartItem({ chart, pos, viewport, getCell, isSelected, onSelect, dataVersion }: ChartItemProps) {
+    const divRef = useRef<HTMLDivElement>(null)
+    const instanceRef = useRef<echarts.ECharts | null>(null)
+
+    // ECharts 인스턴스 초기화 (마운트 1회)
+    useEffect(() => {
+        if (!divRef.current) return
+        const instance = echarts.init(divRef.current, undefined, { renderer: 'canvas' })
+        instanceRef.current = instance
+        instance.setOption(buildEChartsOption(chart, getCell))
+        return () => {
+            instance.dispose()
+            instanceRef.current = null
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // 차트 데이터/설정 변경 시 옵션 갱신
+    useEffect(() => {
+        instanceRef.current?.setOption(buildEChartsOption(chart, getCell), { notMerge: true })
+    }, [chart, getCell, dataVersion])
+
+    // 크기 변경 시 ECharts resize
+    useLayoutEffect(() => {
+        instanceRef.current?.resize({ width: pos.width, height: pos.height })
+    }, [pos.width, pos.height])
+
+    // ── 드래그 이동 ────────────────────────────────────────────────────────────
+    const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+        // 리사이즈 핸들 영역 (우하단 12px) 은 드래그 제외
+        const rect = e.currentTarget.getBoundingClientRect()
+        if (e.clientX > rect.right - 12 && e.clientY > rect.bottom - 12) return
+
+        onSelect()
+        e.stopPropagation()
+        e.preventDefault()
+
+        const startClientX = e.clientX
+        const startClientY = e.clientY
+        const startCanvas = viewport.cellToPixel(chart.anchorRow, chart.anchorCol)
+
+        const onMove = (me: MouseEvent) => {
+            const dx = me.clientX - startClientX
+            const dy = me.clientY - startClientY
+            const { row, col } = viewport.pixelToCell(startCanvas.x + dx, startCanvas.y + dy)
+            chartManager.updateChart(chart.id, {
+                anchorRow: Math.max(0, row),
+                anchorCol: Math.max(0, col),
+            })
+        }
+        const onUp = () => {
+            window.removeEventListener('mousemove', onMove)
+            window.removeEventListener('mouseup', onUp)
+        }
+        window.addEventListener('mousemove', onMove)
+        window.addEventListener('mouseup', onUp)
+    }, [chart, viewport, onSelect])
+
+    // ── 리사이즈 핸들 ─────────────────────────────────────────────────────────
+    const handleResizeDown = useCallback((e: React.MouseEvent) => {
+        e.stopPropagation()
+        e.preventDefault()
+        onSelect()
+
+        const startX = e.clientX
+        const startY = e.clientY
+        const startW = pos.width
+        const startH = pos.height
+
+        const onMove = (me: MouseEvent) => {
+            const targetW = Math.max(80, startW + me.clientX - startX)
+            const targetH = Math.max(60, startH + me.clientY - startY)
+
+            let accW = 0, widthCols = 1
+            for (let c = chart.anchorCol; c < chart.anchorCol + 50; c++) {
+                accW += viewport.getColWidth(c)
+                if (accW >= targetW) { widthCols = c - chart.anchorCol + 1; break }
+            }
+            let accH = 0, heightRows = 1
+            for (let r = chart.anchorRow; r < chart.anchorRow + 100; r++) {
+                accH += viewport.getRowHeight(r)
+                if (accH >= targetH) { heightRows = r - chart.anchorRow + 1; break }
+            }
+            chartManager.updateChart(chart.id, { widthCols, heightRows })
+        }
+        const onUp = () => {
+            window.removeEventListener('mousemove', onMove)
+            window.removeEventListener('mouseup', onUp)
+        }
+        window.addEventListener('mousemove', onMove)
+        window.addEventListener('mouseup', onUp)
+    }, [chart, viewport, pos, onSelect])
+
+    return (
+        <div
+            style={{
+                position: 'absolute',
+                left: pos.x,
+                top: pos.y,
+                width: pos.width,
+                height: pos.height,
+                boxSizing: 'border-box',
+                border: isSelected ? '2px solid #1a73e8' : '1px solid #dadce0',
+                background: '#ffffff',
+                boxShadow: '0 1px 4px rgba(0,0,0,0.12)',
+                cursor: 'move',
+                userSelect: 'none',
+            }}
+            onMouseDown={handleMouseDown}
+        >
+            <div ref={divRef} style={{ width: '100%', height: '100%' }} />
+            {isSelected && (
+                <div
+                    style={{
+                        position: 'absolute',
+                        right: 0,
+                        bottom: 0,
+                        width: 8,
+                        height: 8,
+                        background: '#1a73e8',
+                        cursor: 'se-resize',
+                        zIndex: 1,
+                    }}
+                    onMouseDown={handleResizeDown}
+                />
+            )}
+        </div>
+    )
+}
+
+// ── ChartOverlay 컴포넌트 ────────────────────────────────────────────────────
+
+interface ChartOverlayProps {
+    sheetId: string
+    viewport: ViewportManager
+    getCell: (sheetId: string, row: number, col: number) => CellData | null
+    selectedChartId: string | null
+    onChartSelect: (id: string | null) => void
+    dataVersion: number
+}
+
+export function ChartOverlay({
+    sheetId,
+    viewport,
+    getCell,
+    selectedChartId,
+    onChartSelect,
+    dataVersion,
+}: ChartOverlayProps) {
+    const [charts, setCharts] = useState<ChartDefinition[]>(() =>
+        chartManager.getChartsForSheet(sheetId),
+    )
+    const [, setVpTick] = useState(0)
+
+    // 차트 목록 변경 구독
+    useEffect(() => {
+        return chartManager.subscribe(() => {
+            setCharts(chartManager.getChartsForSheet(sheetId))
+        })
+    }, [sheetId])
+
+    // 뷰포트 변경 구독 (스크롤/리사이즈 시 위치 재계산)
+    useEffect(() => {
+        return viewport.subscribe(() => setVpTick(t => t + 1))
+    }, [viewport])
+
+    return (
+        <>
+            {charts.map(chart => (
+                <ChartItem
+                    key={chart.id}
+                    chart={chart}
+                    pos={calcPos(chart, viewport)}
+                    viewport={viewport}
+                    getCell={getCell}
+                    isSelected={selectedChartId === chart.id}
+                    onSelect={() => onChartSelect(chart.id)}
+                    dataVersion={dataVersion}
+                />
+            ))}
+        </>
+    )
+}

--- a/packages/frontend/src/components/GridCanvas.tsx
+++ b/packages/frontend/src/components/GridCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import type { CellData } from '@cellix/shared'
 import { ViewportManager } from '../core/viewport'
 import { SelectionManager, SelectionRenderer } from '../core/selection'
@@ -9,7 +9,9 @@ import { GridRenderer } from '../core/renderer'
 import { filterManager } from '../core/data'
 import type { FilterCriteria } from '../core/data'
 import { tableManager } from '../core/table'
+import { chartManager } from '../core/chart'
 import { FilterDropdown } from './FilterDropdown'
+import { ChartOverlay } from './ChartOverlay'
 import { useWorkbookStore } from '../store/useWorkbookStore'
 import { useUIStore } from '../store/useUIStore'
 import { formulaEngine } from '../workers'
@@ -41,6 +43,15 @@ export function GridCanvas() {
     const canvasRef = useRef<HTMLCanvasElement>(null)
     const getCellRef = useRef<((row: number, col: number) => CellData | null) | null>(null)
     const [filterDropdown, setFilterDropdown] = React.useState<FilterDropdownState | null>(null)
+
+    // ── 차트 오버레이 상태 ─────────────────────────────────────────────────────
+    const activeSheetId = useWorkbookStore(s => s.activeSheetId)
+    const viewportRef = useRef<ViewportManager | null>(null)
+    const getCellBySheetRef = useRef<((sheetId: string, row: number, col: number) => CellData | null) | null>(null)
+    const [isEngineReady, setIsEngineReady] = useState(false)
+    const [selectedChartId, setSelectedChartId] = useState<string | null>(null)
+    const [chartDataVersion, setChartDataVersion] = useState(0)
+    const [, setChartListVersion] = useState(0)
 
     useEffect(() => {
         const container = containerRef.current
@@ -141,6 +152,17 @@ export function GridCanvas() {
                 () => useWorkbookStore.getState().activeSheetId,
             )
 
+            // ── 차트 오버레이 연결 ────────────────────────────────────────────────
+            viewportRef.current = viewport
+            getCellBySheetRef.current = (sid: string, r: number, c: number) =>
+                useWorkbookStore.getState().getCell(sid, r, c)
+            setIsEngineReady(true)
+
+            // chartManager 변경 시 차트 목록 버전 업데이트
+            const unsubCharts = chartManager.subscribe(() =>
+                setChartListVersion(v => v + 1),
+            )
+
             // ── formulaEngine.onChanged 구독 ─────────────────────────────────────
             const unsubFormula = formulaEngine.onChanged((changed) => {
                 const prev = useWorkbookStore.getState().calculatedValues
@@ -150,6 +172,8 @@ export function GridCanvas() {
                     next[key] = c.value.t === 'nil' ? null : (c.value.v ?? null)
                 }
                 useWorkbookStore.getState().setCalculatedValues(next)
+                // 차트 데이터 자동 갱신
+                setChartDataVersion(v => v + 1)
             })
 
             // ── RAF 렌더 루프용 로컬 상태 ────────────────────────────────────────
@@ -290,6 +314,7 @@ export function GridCanvas() {
                 canvas.removeEventListener('wheel', onWheel)
                 canvas.removeEventListener('click', onCanvasClick)
                 unsubFormula()
+                unsubCharts()
                 unsubFilter()
                 unsubSelection()
                 unsubEdit()
@@ -315,7 +340,21 @@ export function GridCanvas() {
             ref={containerRef}
             style={{ position: 'relative', flex: 1, overflow: 'hidden', minHeight: 0 }}
         >
-            <canvas ref={canvasRef} style={{ display: 'block' }} />
+            <canvas
+                ref={canvasRef}
+                style={{ display: 'block' }}
+                onMouseDown={() => setSelectedChartId(null)}
+            />
+            {isEngineReady && viewportRef.current && getCellBySheetRef.current && (
+                <ChartOverlay
+                    sheetId={activeSheetId}
+                    viewport={viewportRef.current}
+                    getCell={getCellBySheetRef.current}
+                    selectedChartId={selectedChartId}
+                    onChartSelect={setSelectedChartId}
+                    dataVersion={chartDataVersion}
+                />
+            )}
             {filterDropdown && (
                 <FilterDropdown
                     col={filterDropdown.col}

--- a/packages/frontend/src/components/Toolbar.tsx
+++ b/packages/frontend/src/components/Toolbar.tsx
@@ -3,6 +3,7 @@ import type { CellRange, CellStyle } from '@cellix/shared'
 import { useUIStore } from '../store/useUIStore'
 import { useWorkbookStore } from '../store/useWorkbookStore'
 import { styleManager } from '../core/style/StyleManager'
+import { ChartInsertDialog } from './dialogs/ChartInsertDialog'
 
 const BTN: React.CSSProperties = {
     display: 'inline-flex',
@@ -97,6 +98,8 @@ function Btn({ label, title, style, active, disabled, onClick }: BtnProps) {
 export function Toolbar() {
     const { canUndo, canRedo, activeCell, selections } = useUIStore()
     const activeSheetId = useWorkbookStore((s) => s.activeSheetId)
+    const [showChartInsert, setShowChartInsert] = React.useState(false)
+    const [chartInsertRange, setChartInsertRange] = React.useState<CellRange | null>(null)
 
     // styleManager 변경 시 리렌더링
     const [, setStyleVersion] = React.useState(0)
@@ -358,6 +361,28 @@ export function Toolbar() {
                 title="소수점 줄이기"
                 onClick={() => adjustDecimals(-1)}
             />
+
+            <div style={SEP} />
+
+            {/* 차트 삽입 */}
+            <Btn
+                label="📊"
+                title="차트 삽입"
+                style={{ fontSize: 16 }}
+                onClick={() => {
+                    const ranges = getSelectedRanges()
+                    setChartInsertRange(ranges[0] ?? null)
+                    setShowChartInsert(true)
+                }}
+            />
+
+            {showChartInsert && (
+                <ChartInsertDialog
+                    sheetId={activeSheetId}
+                    initialRange={chartInsertRange ?? undefined}
+                    onClose={() => setShowChartInsert(false)}
+                />
+            )}
         </div>
     )
 }

--- a/packages/frontend/src/components/dialogs/ChartInsertDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ChartInsertDialog.tsx
@@ -1,0 +1,200 @@
+import React, { useState } from 'react'
+import type { CellRange } from '@cellix/shared'
+import { chartManager } from '../../core/chart'
+import type { ChartSeries, ChartType } from '../../core/chart'
+
+interface Props {
+    sheetId: string
+    initialRange?: CellRange
+    onClose: () => void
+}
+
+const CHART_TYPES: { type: ChartType; label: string; icon: string }[] = [
+    { type: 'bar', label: '세로 막대형', icon: '▊' },
+    { type: 'bar_stacked', label: '누적 막대형', icon: '▉' },
+    { type: 'line', label: '꺾은선형', icon: '╱' },
+    { type: 'pie', label: '원형', icon: '◕' },
+    { type: 'scatter', label: '분산형', icon: '⁚' },
+    { type: 'combo', label: '혼합형', icon: '╪' },
+]
+
+function colToLetter(col: number): string {
+    let result = ''
+    let n = col + 1
+    while (n > 0) {
+        const r = (n - 1) % 26
+        result = String.fromCharCode(65 + r) + result
+        n = Math.floor((n - 1) / 26)
+    }
+    return result
+}
+
+function rangeToCellRef(range: CellRange): string {
+    const s = range.start
+    const e = range.end
+    return `${colToLetter(s.col)}${s.row + 1}:${colToLetter(e.col)}${e.row + 1}`
+}
+
+function parseRangeRef(ref: string, sheetId: string): CellRange | null {
+    const parts = ref.trim().toUpperCase().split(':')
+    if (parts.length !== 2) return null
+    const parseCell = (s: string) => {
+        const m = s.match(/^([A-Z]+)(\d+)$/)
+        if (!m) return null
+        let col = 0
+        for (const ch of m[1]) col = col * 26 + (ch.charCodeAt(0) - 64)
+        return { row: parseInt(m[2], 10) - 1, col: col - 1, sheetId }
+    }
+    const start = parseCell(parts[0])
+    const end = parseCell(parts[1])
+    if (!start || !end) return null
+    return { start, end }
+}
+
+function autoSeries(range: CellRange, sheetId: string): ChartSeries[] {
+    const c1 = Math.min(range.start.col, range.end.col)
+    const c2 = Math.max(range.start.col, range.end.col)
+    const r1 = Math.min(range.start.row, range.end.row)
+    const r2 = Math.max(range.start.row, range.end.row)
+    const series: ChartSeries[] = []
+    for (let c = c1; c <= c2; c++) {
+        series.push({
+            name: `시리즈 ${c - c1 + 1}`,
+            dataRange: {
+                start: { row: r1, col: c, sheetId },
+                end: { row: r2, col: c, sheetId },
+            },
+        })
+    }
+    return series
+}
+
+export function ChartInsertDialog({ sheetId, initialRange, onClose }: Props) {
+    const [chartType, setChartType] = useState<ChartType>('bar')
+    const [title, setTitle] = useState('')
+    const [dataRangeStr, setDataRangeStr] = useState(
+        initialRange ? rangeToCellRef(initialRange) : '',
+    )
+    const [categoryRangeStr, setCategoryRangeStr] = useState('')
+    const [error, setError] = useState<string | null>(null)
+
+    const handleCreate = () => {
+        setError(null)
+        const dataRange = parseRangeRef(dataRangeStr, sheetId)
+        if (!dataRange) { setError('데이터 범위가 올바르지 않습니다. (예: A1:B5)'); return }
+
+        const categoryRange = categoryRangeStr.trim()
+            ? parseRangeRef(categoryRangeStr, sheetId) ?? undefined
+            : undefined
+
+        const series = autoSeries(dataRange, sheetId)
+        const anchorRow = (initialRange?.end.row ?? 0) + 2
+        const anchorCol = initialRange?.start.col ?? 0
+
+        chartManager.createChart({
+            sheetId,
+            type: chartType,
+            title: title.trim() || undefined,
+            anchorRow,
+            anchorCol,
+            widthCols: 8,
+            heightRows: 15,
+            categoryRange,
+            series,
+            legendPosition: 'bottom',
+        })
+
+        onClose()
+    }
+
+    return (
+        <div
+            style={{
+                position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.3)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+            }}
+            onMouseDown={onClose}
+        >
+            <div
+                style={{
+                    background: '#fff', borderRadius: 6, padding: 24, minWidth: 360,
+                    boxShadow: '0 4px 24px rgba(0,0,0,0.18)', fontFamily: 'system-ui, sans-serif',
+                    fontSize: 13,
+                }}
+                onMouseDown={e => e.stopPropagation()}
+            >
+                <h3 style={{ margin: '0 0 16px', fontSize: 15, fontWeight: 600 }}>차트 삽입</h3>
+
+                {/* 차트 종류 선택 */}
+                <label style={labelSt}>차트 종류</label>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 14 }}>
+                    {CHART_TYPES.map(ct => (
+                        <button
+                            key={ct.type}
+                            style={{
+                                display: 'flex', flexDirection: 'column', alignItems: 'center',
+                                gap: 4, padding: '8px 12px', borderRadius: 6, cursor: 'pointer',
+                                border: chartType === ct.type ? '2px solid #1a73e8' : '1px solid #dadce0',
+                                background: chartType === ct.type ? '#e8f0fe' : '#fff',
+                                color: chartType === ct.type ? '#1a73e8' : '#3c4043',
+                                fontSize: 11, fontWeight: 500, minWidth: 70,
+                            }}
+                            onClick={() => setChartType(ct.type)}
+                        >
+                            <span style={{ fontSize: 20 }}>{ct.icon}</span>
+                            {ct.label}
+                        </button>
+                    ))}
+                </div>
+
+                <label style={labelSt}>데이터 범위</label>
+                <input
+                    style={inputSt}
+                    placeholder="예: A1:C10"
+                    value={dataRangeStr}
+                    onChange={e => setDataRangeStr(e.target.value)}
+                />
+
+                <label style={labelSt}>범주(X축) 범위 (선택)</label>
+                <input
+                    style={inputSt}
+                    placeholder="예: A1:A10"
+                    value={categoryRangeStr}
+                    onChange={e => setCategoryRangeStr(e.target.value)}
+                />
+
+                <label style={labelSt}>차트 제목 (선택)</label>
+                <input
+                    style={inputSt}
+                    placeholder="차트 제목"
+                    value={title}
+                    onChange={e => setTitle(e.target.value)}
+                />
+
+                {error && <div style={{ color: '#c0392b', marginBottom: 8 }}>{error}</div>}
+
+                <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 4 }}>
+                    <button style={btnSt('#f1f3f4', '#202124')} onClick={onClose}>취소</button>
+                    <button style={btnSt('#1a73e8', '#fff')} onClick={handleCreate}>확인</button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const labelSt: React.CSSProperties = {
+    display: 'block', marginBottom: 4, fontWeight: 500, color: '#5f6368',
+}
+
+const inputSt: React.CSSProperties = {
+    display: 'block', width: '100%', marginBottom: 12,
+    border: '1px solid #dadce0', borderRadius: 4, padding: '6px 8px',
+    fontSize: 13, outline: 'none', boxSizing: 'border-box',
+}
+
+function btnSt(bg: string, color: string): React.CSSProperties {
+    return {
+        padding: '6px 16px', borderRadius: 4, border: 'none', background: bg,
+        color, cursor: 'pointer', fontSize: 13, fontWeight: 500,
+    }
+}

--- a/packages/frontend/src/core/chart/ChartDataMapper.ts
+++ b/packages/frontend/src/core/chart/ChartDataMapper.ts
@@ -1,0 +1,144 @@
+import type { CellData, CellRange } from '@cellix/shared'
+import type { EChartsOption } from 'echarts'
+import type { ChartAxis, ChartDefinition } from './types'
+
+function readRange(
+    range: CellRange,
+    getCell: (sheetId: string, row: number, col: number) => CellData | null,
+): (string | number | null)[] {
+    const values: (string | number | null)[] = []
+    const sheetId = range.start.sheetId
+    const r1 = Math.min(range.start.row, range.end.row)
+    const r2 = Math.max(range.start.row, range.end.row)
+    const c1 = Math.min(range.start.col, range.end.col)
+    const c2 = Math.max(range.start.col, range.end.col)
+    for (let r = r1; r <= r2; r++) {
+        for (let c = c1; c <= c2; c++) {
+            const v = getCell(sheetId, r, c)?.value
+            values.push(typeof v === 'string' || typeof v === 'number' ? v : null)
+        }
+    }
+    return values
+}
+
+function axisOpts(axis?: ChartAxis): Record<string, unknown> {
+    if (!axis) return {}
+    const o: Record<string, unknown> = {}
+    if (axis.title) o['name'] = axis.title
+    if (axis.min !== undefined) o['min'] = axis.min
+    if (axis.max !== undefined) o['max'] = axis.max
+    if (axis.gridLines === false) o['splitLine'] = { show: false }
+    return o
+}
+
+export function buildEChartsOption(
+    chart: ChartDefinition,
+    getCell: (sheetId: string, row: number, col: number) => CellData | null,
+): EChartsOption {
+    const categories = chart.categoryRange
+        ? readRange(chart.categoryRange, getCell).map(v => (v == null ? '' : String(v)))
+        : undefined
+
+    const seriesData = chart.series.map(s => ({
+        name: s.name,
+        data: readRange(s.dataRange, getCell),
+        chartType: s.chartType,
+        yAxisIndex: s.yAxisIndex ?? 0,
+    }))
+
+    const titleOpt = chart.title
+        ? { text: chart.title, left: 'center' as const, textStyle: { fontSize: 13 } }
+        : undefined
+
+    const legendOpt: EChartsOption['legend'] = chart.legendPosition === 'none'
+        ? { show: false }
+        : { show: true }
+
+    switch (chart.type) {
+        case 'bar':
+            return {
+                title: titleOpt,
+                legend: legendOpt,
+                tooltip: { trigger: 'axis' as const },
+                xAxis: { type: 'category' as const, data: categories },
+                yAxis: { type: 'value' as const, ...axisOpts(chart.yAxis) },
+                series: seriesData.map(s => ({ type: 'bar' as const, name: s.name, data: s.data })),
+            }
+
+        case 'bar_stacked':
+            return {
+                title: titleOpt,
+                legend: legendOpt,
+                tooltip: { trigger: 'axis' as const },
+                xAxis: { type: 'category' as const, data: categories },
+                yAxis: { type: 'value' as const, ...axisOpts(chart.yAxis) },
+                series: seriesData.map(s => ({
+                    type: 'bar' as const, name: s.name, data: s.data, stack: 'total',
+                })),
+            }
+
+        case 'line':
+            return {
+                title: titleOpt,
+                legend: legendOpt,
+                tooltip: { trigger: 'axis' as const },
+                xAxis: { type: 'category' as const, data: categories },
+                yAxis: { type: 'value' as const, ...axisOpts(chart.yAxis) },
+                series: seriesData.map(s => ({ type: 'line' as const, name: s.name, data: s.data })),
+            }
+
+        case 'pie': {
+            const first = seriesData[0]
+            const pieData = first
+                ? first.data.map((v, i) => ({
+                    value: typeof v === 'number' ? v : 0,
+                    name: categories?.[i] ?? `항목 ${i + 1}`,
+                }))
+                : []
+            return {
+                title: titleOpt,
+                legend: { show: chart.legendPosition !== 'none', orient: 'vertical' as const, right: '5%', top: 'center' as const },
+                tooltip: { trigger: 'item' as const },
+                series: [{ type: 'pie' as const, radius: '60%', data: pieData, label: { formatter: '{b}: {d}%' } }],
+            }
+        }
+
+        case 'scatter': {
+            const xData = seriesData[0]?.data ?? []
+            const yData = seriesData[1]?.data ?? xData
+            const scatterData = xData.map((x, i) => [typeof x === 'number' ? x : 0, typeof yData[i] === 'number' ? yData[i] : 0])
+            return {
+                title: titleOpt,
+                tooltip: { trigger: 'item' as const },
+                xAxis: { type: 'value' as const, ...axisOpts(chart.xAxis) },
+                yAxis: { type: 'value' as const, ...axisOpts(chart.yAxis) },
+                series: [{ type: 'scatter' as const, data: scatterData }],
+            }
+        }
+
+        case 'combo': {
+            const hasSecond = seriesData.some(s => s.yAxisIndex === 1)
+            return {
+                title: titleOpt,
+                legend: legendOpt,
+                tooltip: { trigger: 'axis' as const },
+                xAxis: { type: 'category' as const, data: categories },
+                yAxis: hasSecond
+                    ? [
+                        { type: 'value' as const, ...axisOpts(chart.yAxis) },
+                        { type: 'value' as const, ...axisOpts(chart.yAxis2) },
+                    ]
+                    : { type: 'value' as const, ...axisOpts(chart.yAxis) },
+                series: seriesData.map(s => ({
+                    type: (s.chartType ?? 'bar') as 'bar' | 'line',
+                    name: s.name,
+                    data: s.data,
+                    yAxisIndex: s.yAxisIndex ?? 0,
+                })),
+            }
+        }
+
+        default:
+            return {}
+    }
+}

--- a/packages/frontend/src/core/chart/ChartManager.ts
+++ b/packages/frontend/src/core/chart/ChartManager.ts
@@ -1,0 +1,54 @@
+import type { ChartDefinition } from './types'
+
+export class ChartManager {
+    private readonly charts = new Map<string, ChartDefinition>()
+    private readonly listeners = new Set<() => void>()
+
+    createChart(def: Omit<ChartDefinition, 'id'>): ChartDefinition {
+        const id = crypto.randomUUID()
+        const chart: ChartDefinition = { ...def, id }
+        this.charts.set(id, chart)
+        this._notify()
+        return chart
+    }
+
+    updateChart(id: string, patch: Partial<ChartDefinition>): void {
+        const existing = this.charts.get(id)
+        if (!existing) return
+        this.charts.set(id, { ...existing, ...patch })
+        this._notify()
+    }
+
+    deleteChart(id: string): void {
+        this.charts.delete(id)
+        this._notify()
+    }
+
+    getChartsForSheet(sheetId: string): ChartDefinition[] {
+        return [...this.charts.values()].filter(c => c.sheetId === sheetId)
+    }
+
+    getChartAt(sheetId: string, row: number, col: number): ChartDefinition | null {
+        for (const chart of this.charts.values()) {
+            if (chart.sheetId !== sheetId) continue
+            if (
+                row >= chart.anchorRow && row < chart.anchorRow + chart.heightRows &&
+                col >= chart.anchorCol && col < chart.anchorCol + chart.widthCols
+            ) {
+                return chart
+            }
+        }
+        return null
+    }
+
+    subscribe(listener: () => void): () => void {
+        this.listeners.add(listener)
+        return () => this.listeners.delete(listener)
+    }
+
+    private _notify(): void {
+        for (const fn of this.listeners) fn()
+    }
+}
+
+export const chartManager = new ChartManager()

--- a/packages/frontend/src/core/chart/index.ts
+++ b/packages/frontend/src/core/chart/index.ts
@@ -1,0 +1,3 @@
+export { ChartManager, chartManager } from './ChartManager'
+export { buildEChartsOption } from './ChartDataMapper'
+export type { ChartDefinition, ChartSeries, ChartAxis, ChartType } from './types'

--- a/packages/frontend/src/core/chart/types.ts
+++ b/packages/frontend/src/core/chart/types.ts
@@ -1,0 +1,36 @@
+import type { CellRange } from '@cellix/shared'
+
+export type ChartType = 'bar' | 'bar_stacked' | 'line' | 'pie' | 'scatter' | 'combo'
+
+export interface ChartAxis {
+    title?: string
+    min?: number
+    max?: number
+    gridLines?: boolean
+}
+
+export interface ChartSeries {
+    name: string
+    dataRange: CellRange
+    chartType?: 'bar' | 'line'   // combo용
+    yAxisIndex?: 0 | 1            // 이중 축
+}
+
+export interface ChartDefinition {
+    id: string
+    sheetId: string
+    type: ChartType
+    title?: string
+    // 차트 위치 (셀 기반)
+    anchorRow: number
+    anchorCol: number
+    widthCols: number
+    heightRows: number
+    // 데이터
+    categoryRange?: CellRange
+    series: ChartSeries[]
+    xAxis?: ChartAxis
+    yAxis?: ChartAxis
+    yAxis2?: ChartAxis
+    legendPosition?: 'top' | 'bottom' | 'left' | 'right' | 'none'
+}

--- a/packages/frontend/src/core/pivot/PivotEngine.ts
+++ b/packages/frontend/src/core/pivot/PivotEngine.ts
@@ -1,0 +1,372 @@
+import type { CellData, CellValue, CellAddress, CellStyle } from '@cellix/shared'
+import type { PivotDefinition, PivotField, AggregationType } from './types'
+
+interface PivotData {
+    headers: string[][]
+    colHeaders: string[][]
+    values: (number | null)[][]
+    rowGrandTotals?: (number | null)[]
+    colGrandTotals?: (number | null)[]
+    grandTotal?: number | null
+}
+
+export class PivotEngine {
+    calculate(
+        def: PivotDefinition,
+        getCell: (sheetId: string, row: number, col: number) => CellData | null,
+    ): PivotData {
+        const records = this._readSourceData(def, getCell)
+
+        if (records.length === 0 || def.valueFields.length === 0) {
+            return { headers: [], colHeaders: [], values: [] }
+        }
+
+        const rowCombos: CellValue[][] =
+            def.rowFields.length > 0
+                ? this._uniqueCombos(records, def.rowFields)
+                : [[]]
+
+        const colCombos: CellValue[][] | null =
+            def.colFields.length > 0 ? this._uniqueCombos(records, def.colFields) : null
+
+        // ── Build column headers ─────────────────────────────────────────────
+        let colHeaders: string[][]
+        let numDataCols: number
+
+        if (colCombos === null) {
+            colHeaders = [def.valueFields.map((f) => f.displayName ?? f.fieldName)]
+            numDataCols = def.valueFields.length
+        } else {
+            numDataCols = colCombos.length * def.valueFields.length
+            const levels = def.colFields.length
+            colHeaders = Array.from({ length: levels }, () => [] as string[])
+
+            for (const combo of colCombos) {
+                for (let vi = 0; vi < def.valueFields.length; vi++) {
+                    for (let li = 0; li < levels; li++) {
+                        colHeaders[li].push(String(combo[li] ?? ''))
+                    }
+                }
+            }
+            if (def.valueFields.length > 1) {
+                const vfRow: string[] = []
+                for (let ci = 0; ci < colCombos.length; ci++) {
+                    for (const vf of def.valueFields) {
+                        vfRow.push(vf.displayName ?? vf.fieldName)
+                    }
+                }
+                colHeaders.push(vfRow)
+            }
+        }
+
+        // ── Build row headers ────────────────────────────────────────────────
+        const headers: string[][] = rowCombos.map((combo) => combo.map((v) => String(v ?? '')))
+
+        // ── Build values grid ────────────────────────────────────────────────
+        const values: (number | null)[][] = []
+
+        for (const rowCombo of rowCombos) {
+            const rowRecords =
+                def.rowFields.length > 0
+                    ? records.filter((r) =>
+                          def.rowFields.every((f, i) => this._valEq(r[f.fieldName], rowCombo[i])),
+                      )
+                    : records
+
+            const rowData: (number | null)[] = []
+
+            if (colCombos === null) {
+                for (const vf of def.valueFields) {
+                    const vals = rowRecords.map((r) => r[vf.fieldName])
+                    rowData.push(this._aggregate(vals, vf.aggregation))
+                }
+            } else {
+                for (const colCombo of colCombos) {
+                    const colRecords = rowRecords.filter((r) =>
+                        def.colFields.every((f, i) => this._valEq(r[f.fieldName], colCombo[i])),
+                    )
+                    for (const vf of def.valueFields) {
+                        const vals = colRecords.map((r) => r[vf.fieldName])
+                        rowData.push(this._aggregate(vals, vf.aggregation))
+                    }
+                }
+            }
+
+            values.push(rowData)
+        }
+
+        // ── Grand totals ─────────────────────────────────────────────────────
+        let rowGrandTotals: (number | null)[] | undefined
+        let colGrandTotals: (number | null)[] | undefined
+        let grandTotal: number | null | undefined
+
+        if (def.showRowGrandTotal) {
+            rowGrandTotals = Array.from({ length: numDataCols }, (_, ci) => {
+                const nums = values
+                    .map((row) => row[ci])
+                    .filter((v): v is number => typeof v === 'number')
+                return nums.length > 0 ? nums.reduce((a, b) => a + b, 0) : null
+            })
+        }
+
+        if (def.showColGrandTotal) {
+            colGrandTotals = values.map((row) => {
+                const nums = row.filter((v): v is number => typeof v === 'number')
+                return nums.length > 0 ? nums.reduce((a, b) => a + b, 0) : null
+            })
+        }
+
+        if (def.showRowGrandTotal && def.showColGrandTotal) {
+            const allNums = values
+                .flat()
+                .filter((v): v is number => typeof v === 'number')
+            grandTotal = allNums.length > 0 ? allNums.reduce((a, b) => a + b, 0) : null
+        }
+
+        return { headers, colHeaders, values, rowGrandTotals, colGrandTotals, grandTotal }
+    }
+
+    writeToSheet(
+        data: PivotData,
+        def: PivotDefinition,
+        setCell: (sheetId: string, row: number, col: number, cellData: CellData) => void,
+    ): void {
+        const { targetSheetId: sid, targetStartRow: r0, targetStartCol: c0 } = def
+        const numRowFields = Math.max(def.rowFields.length, 1)
+        const numColLevels = data.colHeaders.length
+        const numDataRows = data.values.length
+        const numDataCols = data.values[0]?.length ?? 0
+
+        const hdrStyle: CellStyle = {
+            font: { weight: 'bold' },
+            backgroundColor: '#f3f4f6',
+        }
+        const totalStyle: CellStyle = {
+            font: { weight: 'bold' },
+            backgroundColor: '#e5e7eb',
+        }
+
+        // ── 1. Column header rows ────────────────────────────────────────────
+        for (let li = 0; li < numColLevels; li++) {
+            for (let fc = 0; fc < numRowFields; fc++) {
+                setCell(sid, r0 + li, c0 + fc, { value: null, style: hdrStyle })
+            }
+            for (let ci = 0; ci < numDataCols; ci++) {
+                setCell(sid, r0 + li, c0 + numRowFields + ci, {
+                    value: data.colHeaders[li]?.[ci] ?? null,
+                    style: hdrStyle,
+                })
+            }
+            if (def.showColGrandTotal) {
+                setCell(sid, r0 + li, c0 + numRowFields + numDataCols, {
+                    value: li === numColLevels - 1 ? '총합계' : null,
+                    style: hdrStyle,
+                })
+            }
+        }
+
+        // ── 2. Row header merge spans ────────────────────────────────────────
+        const rowSpans = this._computeRowSpans(data.headers, numRowFields)
+
+        // ── 3. Data rows ─────────────────────────────────────────────────────
+        for (let ri = 0; ri < numDataRows; ri++) {
+            const absRow = r0 + numColLevels + ri
+
+            for (let fi = 0; fi < numRowFields; fi++) {
+                const key = `${ri}:${fi}`
+                const span = rowSpans.get(key) ?? 1
+                const val = data.headers[ri]?.[fi] ?? ''
+
+                if (span === 0) {
+                    const masterRi = this._findMasterRow(ri, fi, data.headers)
+                    const masterAddr: CellAddress = {
+                        row: r0 + numColLevels + masterRi,
+                        col: c0 + fi,
+                        sheetId: sid,
+                    }
+                    setCell(sid, absRow, c0 + fi, {
+                        value: null,
+                        style: hdrStyle,
+                        mergeInfo: { rowSpan: 1, colSpan: 1, isMerged: true, masterCell: masterAddr },
+                    })
+                } else {
+                    setCell(sid, absRow, c0 + fi, {
+                        value: val,
+                        style: hdrStyle,
+                        mergeInfo:
+                            span > 1
+                                ? { rowSpan: span, colSpan: 1, isMerged: false }
+                                : undefined,
+                    })
+                }
+            }
+
+            for (let ci = 0; ci < numDataCols; ci++) {
+                setCell(sid, absRow, c0 + numRowFields + ci, {
+                    value: data.values[ri]?.[ci] ?? null,
+                })
+            }
+
+            if (def.showColGrandTotal && data.colGrandTotals) {
+                setCell(sid, absRow, c0 + numRowFields + numDataCols, {
+                    value: data.colGrandTotals[ri] ?? null,
+                    style: totalStyle,
+                })
+            }
+        }
+
+        // ── 4. Row grand total row ───────────────────────────────────────────
+        if (def.showRowGrandTotal && data.rowGrandTotals) {
+            const absRow = r0 + numColLevels + numDataRows
+            setCell(sid, absRow, c0, { value: '총합계', style: totalStyle })
+            for (let fi = 1; fi < numRowFields; fi++) {
+                setCell(sid, absRow, c0 + fi, { value: null, style: totalStyle })
+            }
+            for (let ci = 0; ci < numDataCols; ci++) {
+                setCell(sid, absRow, c0 + numRowFields + ci, {
+                    value: data.rowGrandTotals[ci] ?? null,
+                    style: totalStyle,
+                })
+            }
+            if (def.showColGrandTotal && data.grandTotal !== undefined) {
+                setCell(sid, absRow, c0 + numRowFields + numDataCols, {
+                    value: data.grandTotal,
+                    style: totalStyle,
+                })
+            }
+        }
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private _readSourceData(
+        def: PivotDefinition,
+        getCell: (sheetId: string, row: number, col: number) => CellData | null,
+    ): Record<string, CellValue>[] {
+        const { start, end } = def.sourceRange
+        const { sourceSheetId } = def
+
+        const headerNames: string[] = []
+        for (let c = start.col; c <= end.col; c++) {
+            const cell = getCell(sourceSheetId, start.row, c)
+            headerNames.push(String(cell?.value ?? `Col${c - start.col + 1}`))
+        }
+
+        const records: Record<string, CellValue>[] = []
+        for (let r = start.row + 1; r <= end.row; r++) {
+            const record: Record<string, CellValue> = {}
+            for (let c = start.col; c <= end.col; c++) {
+                const cell = getCell(sourceSheetId, r, c)
+                record[headerNames[c - start.col]!] = cell?.value ?? null
+            }
+            records.push(record)
+        }
+        return records
+    }
+
+    private _uniqueCombos(
+        records: Record<string, CellValue>[],
+        fields: PivotField[],
+    ): CellValue[][] {
+        const seen = new Set<string>()
+        const result: CellValue[][] = []
+        for (const r of records) {
+            const combo = fields.map((f) => r[f.fieldName] ?? null)
+            const key = JSON.stringify(combo)
+            if (!seen.has(key)) {
+                seen.add(key)
+                result.push(combo)
+            }
+        }
+        return result
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private _groupBy(records: Record<string, CellValue>[], fields: PivotField[]): Map<string, any> {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = new Map<string, any>()
+        const [first, ...rest] = fields
+        if (!first) return result
+
+        for (const r of records) {
+            const key = String(r[first.fieldName] ?? '')
+            if (!result.has(key)) result.set(key, [])
+            ;(result.get(key) as Record<string, CellValue>[]).push(r)
+        }
+
+        if (rest.length > 0) {
+            for (const [key, group] of result.entries()) {
+                result.set(key, this._groupBy(group as Record<string, CellValue>[], rest))
+            }
+        }
+
+        return result
+    }
+
+    private _aggregate(values: CellValue[], type: AggregationType): number | null {
+        const nums = values.filter((v): v is number => typeof v === 'number')
+        const nonNull = values.filter((v) => v !== null)
+
+        switch (type) {
+            case 'sum':
+                return nums.length > 0 ? nums.reduce((a, b) => a + b, 0) : null
+            case 'count':
+                return nonNull.length
+            case 'countNumbers':
+                return nums.length
+            case 'average':
+                return nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : null
+            case 'max':
+                return nums.length > 0 ? Math.max(...nums) : null
+            case 'min':
+                return nums.length > 0 ? Math.min(...nums) : null
+            case 'product':
+                return nums.length > 0 ? nums.reduce((a, b) => a * b, 1) : null
+        }
+    }
+
+    private _valEq(a: CellValue | undefined, b: CellValue | undefined): boolean {
+        if ((a ?? null) === null && (b ?? null) === null) return true
+        return String(a ?? '') === String(b ?? '')
+    }
+
+    private _computeRowSpans(headers: string[][], numRowFields: number): Map<string, number> {
+        const spans = new Map<string, number>()
+        for (let fi = 0; fi < numRowFields; fi++) {
+            let ri = 0
+            while (ri < headers.length) {
+                let end = ri + 1
+                while (end < headers.length && this._sameParentGroup(headers, ri, end, fi)) {
+                    end++
+                }
+                const span = end - ri
+                spans.set(`${ri}:${fi}`, span)
+                for (let si = ri + 1; si < end; si++) {
+                    spans.set(`${si}:${fi}`, 0)
+                }
+                ri = end
+            }
+        }
+        return spans
+    }
+
+    private _sameParentGroup(
+        headers: string[][],
+        baseRow: number,
+        checkRow: number,
+        upToField: number,
+    ): boolean {
+        for (let fi = 0; fi <= upToField; fi++) {
+            if ((headers[baseRow]?.[fi] ?? '') !== (headers[checkRow]?.[fi] ?? '')) return false
+        }
+        return true
+    }
+
+    private _findMasterRow(row: number, fi: number, headers: string[][]): number {
+        let master = row - 1
+        while (master >= 0 && this._sameParentGroup(headers, master, row, fi)) {
+            master--
+        }
+        return master + 1
+    }
+}

--- a/packages/frontend/src/core/pivot/PivotFieldPanel.tsx
+++ b/packages/frontend/src/core/pivot/PivotFieldPanel.tsx
@@ -1,0 +1,462 @@
+import React, { useState, useCallback } from 'react'
+import {
+    DndContext,
+    DragOverlay,
+    useDroppable,
+    type DragEndEvent,
+    type DragStartEvent,
+} from '@dnd-kit/core'
+import {
+    SortableContext,
+    arrayMove,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type { PivotDefinition, PivotField, PivotValueField, AggregationType } from './types'
+
+// ── Zone types ───────────────────────────────────────────────────────────────
+
+type ZoneId = 'available' | 'filters' | 'columns' | 'rows' | 'values'
+
+const ZONE_LABELS: Record<ZoneId, string> = {
+    available: '사용 가능한 필드',
+    filters: '필터',
+    columns: '열',
+    rows: '행',
+    values: '값',
+}
+
+const AGG_OPTIONS: { value: AggregationType; label: string }[] = [
+    { value: 'sum', label: '합계' },
+    { value: 'count', label: '개수' },
+    { value: 'average', label: '평균' },
+    { value: 'max', label: '최대값' },
+    { value: 'min', label: '최소값' },
+    { value: 'countNumbers', label: '숫자 개수' },
+    { value: 'product', label: '곱' },
+]
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function getFieldZone(fieldName: string, def: PivotDefinition): ZoneId {
+    if (def.filterFields.some((f) => f.fieldName === fieldName)) return 'filters'
+    if (def.colFields.some((f) => f.fieldName === fieldName)) return 'columns'
+    if (def.rowFields.some((f) => f.fieldName === fieldName)) return 'rows'
+    if (def.valueFields.some((f) => f.fieldName === fieldName)) return 'values'
+    return 'available'
+}
+
+function getZoneFieldNames(def: PivotDefinition, zone: ZoneId): string[] {
+    switch (zone) {
+        case 'filters':
+            return def.filterFields.map((f) => f.fieldName)
+        case 'columns':
+            return def.colFields.map((f) => f.fieldName)
+        case 'rows':
+            return def.rowFields.map((f) => f.fieldName)
+        case 'values':
+            return def.valueFields.map((f) => f.fieldName)
+        default:
+            return []
+    }
+}
+
+function removeFromZone(def: PivotDefinition, fieldName: string, zone: ZoneId): PivotDefinition {
+    switch (zone) {
+        case 'filters':
+            return { ...def, filterFields: def.filterFields.filter((f) => f.fieldName !== fieldName) }
+        case 'columns':
+            return { ...def, colFields: def.colFields.filter((f) => f.fieldName !== fieldName) }
+        case 'rows':
+            return { ...def, rowFields: def.rowFields.filter((f) => f.fieldName !== fieldName) }
+        case 'values':
+            return { ...def, valueFields: def.valueFields.filter((f) => f.fieldName !== fieldName) }
+        default:
+            return def
+    }
+}
+
+function addToZone(def: PivotDefinition, fieldName: string, zone: ZoneId): PivotDefinition {
+    const field: PivotField = { fieldName }
+    switch (zone) {
+        case 'filters':
+            return { ...def, filterFields: [...def.filterFields, field] }
+        case 'columns':
+            return { ...def, colFields: [...def.colFields, field] }
+        case 'rows':
+            return { ...def, rowFields: [...def.rowFields, field] }
+        case 'values': {
+            const vf: PivotValueField = { fieldName, aggregation: 'sum' }
+            return { ...def, valueFields: [...def.valueFields, vf] }
+        }
+        default:
+            return def
+    }
+}
+
+function reorderZone(def: PivotDefinition, zone: ZoneId, oldIdx: number, newIdx: number): PivotDefinition {
+    switch (zone) {
+        case 'filters':
+            return { ...def, filterFields: arrayMove(def.filterFields, oldIdx, newIdx) }
+        case 'columns':
+            return { ...def, colFields: arrayMove(def.colFields, oldIdx, newIdx) }
+        case 'rows':
+            return { ...def, rowFields: arrayMove(def.rowFields, oldIdx, newIdx) }
+        case 'values':
+            return { ...def, valueFields: arrayMove(def.valueFields, oldIdx, newIdx) }
+        default:
+            return def
+    }
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+interface SortableItemProps {
+    id: string
+    zone: ZoneId
+    label: string
+    children?: React.ReactNode
+}
+
+function SortableItem({ id, zone, label, children }: SortableItemProps) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+        id,
+        data: { zone },
+    })
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '3px 6px',
+                margin: '2px 0',
+                background: '#ffffff',
+                border: '1px solid #d1d5db',
+                borderRadius: 4,
+                opacity: isDragging ? 0.4 : 1,
+                fontSize: 12,
+                userSelect: 'none',
+                transform: CSS.Transform.toString(transform),
+                transition,
+            }}
+        >
+            <span
+                {...attributes}
+                {...listeners}
+                style={{
+                    flex: 1,
+                    cursor: 'grab',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                ⠿ {label}
+            </span>
+            {children}
+        </div>
+    )
+}
+
+interface DroppableZoneProps {
+    id: ZoneId
+    label: string
+    itemIds: string[]
+    children: React.ReactNode
+}
+
+function DroppableZone({ id, label, itemIds, children }: DroppableZoneProps) {
+    const { setNodeRef, isOver } = useDroppable({ id, data: { zone: id } })
+
+    return (
+        <div style={{ marginBottom: 8 }}>
+            {label && (
+                <div
+                    style={{
+                        fontSize: 11,
+                        fontWeight: 600,
+                        color: '#6b7280',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.05em',
+                        marginBottom: 4,
+                    }}
+                >
+                    {label}
+                </div>
+            )}
+            <div
+                ref={setNodeRef}
+                style={{
+                    minHeight: 50,
+                    background: isOver ? '#eff6ff' : '#f9fafb',
+                    border: `1px dashed ${isOver ? '#3b82f6' : '#d1d5db'}`,
+                    borderRadius: 6,
+                    padding: '4px',
+                    transition: 'background 0.1s, border-color 0.1s',
+                }}
+            >
+                <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+                    {children}
+                </SortableContext>
+            </div>
+        </div>
+    )
+}
+
+// ── Main Component ───────────────────────────────────────────────────────────
+
+export interface PivotFieldPanelProps {
+    definition: PivotDefinition
+    availableFields: string[]
+    onUpdate: (def: PivotDefinition) => void
+}
+
+export function PivotFieldPanel({ definition, availableFields, onUpdate }: PivotFieldPanelProps) {
+    const [activeId, setActiveId] = useState<string | null>(null)
+
+    const usedFields = new Set([
+        ...definition.filterFields.map((f) => f.fieldName),
+        ...definition.colFields.map((f) => f.fieldName),
+        ...definition.rowFields.map((f) => f.fieldName),
+        ...definition.valueFields.map((f) => f.fieldName),
+    ])
+
+    const unusedFields = availableFields.filter((f) => !usedFields.has(f))
+
+    const handleDragStart = useCallback(({ active }: DragStartEvent) => {
+        setActiveId(String(active.id))
+    }, [])
+
+    const handleDragEnd = useCallback(
+        ({ active, over }: DragEndEvent) => {
+            setActiveId(null)
+            if (!over) return
+
+            const fieldName = String(active.id)
+            const targetZone = (over.data.current?.zone ?? String(over.id)) as ZoneId
+            const sourceZone = getFieldZone(fieldName, definition)
+
+            if (sourceZone === targetZone) {
+                // Same zone: reorder
+                if (sourceZone === 'available') return
+                const names = getZoneFieldNames(definition, sourceZone)
+                const oldIdx = names.indexOf(fieldName)
+                const newIdx = names.indexOf(String(over.id))
+                if (oldIdx !== -1 && newIdx !== -1 && oldIdx !== newIdx) {
+                    onUpdate(reorderZone(definition, sourceZone, oldIdx, newIdx))
+                }
+                return
+            }
+
+            // Cross-zone move
+            let newDef =
+                sourceZone !== 'available'
+                    ? removeFromZone(definition, fieldName, sourceZone)
+                    : definition
+            newDef = addToZone(newDef, fieldName, targetZone)
+            onUpdate(newDef)
+        },
+        [definition, onUpdate],
+    )
+
+    const handleAggChange = (fieldName: string, agg: AggregationType) => {
+        onUpdate({
+            ...definition,
+            valueFields: definition.valueFields.map((f) =>
+                f.fieldName === fieldName ? { ...f, aggregation: agg } : f,
+            ),
+        })
+    }
+
+    const handleRemove = (fieldName: string, zone: Exclude<ZoneId, 'available'>) => {
+        onUpdate(removeFromZone(definition, fieldName, zone))
+    }
+
+    const filterIds = definition.filterFields.map((f) => f.fieldName)
+    const colIds = definition.colFields.map((f) => f.fieldName)
+    const rowIds = definition.rowFields.map((f) => f.fieldName)
+    const valueIds = definition.valueFields.map((f) => f.fieldName)
+
+    return (
+        <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+            <div
+                style={{
+                    width: 224,
+                    padding: 12,
+                    background: '#f3f4f6',
+                    borderLeft: '1px solid #e5e7eb',
+                    overflowY: 'auto',
+                    height: '100%',
+                    boxSizing: 'border-box',
+                    fontFamily: 'inherit',
+                }}
+            >
+                {/* Available fields */}
+                <div style={{ marginBottom: 12 }}>
+                    <div
+                        style={{
+                            fontSize: 11,
+                            fontWeight: 700,
+                            color: '#374151',
+                            marginBottom: 6,
+                        }}
+                    >
+                        {ZONE_LABELS.available}
+                    </div>
+                    <DroppableZone id="available" label="" itemIds={unusedFields}>
+                        {unusedFields.length === 0 ? (
+                            <div
+                                style={{ fontSize: 11, color: '#9ca3af', padding: '8px 6px', textAlign: 'center' }}
+                            >
+                                모든 필드 사용 중
+                            </div>
+                        ) : (
+                            unusedFields.map((f) => (
+                                <SortableItem key={f} id={f} zone="available" label={f} />
+                            ))
+                        )}
+                    </DroppableZone>
+                </div>
+
+                <hr style={{ border: 'none', borderTop: '1px solid #d1d5db', marginBottom: 12 }} />
+
+                {/* Filter zone */}
+                <DroppableZone id="filters" label={ZONE_LABELS.filters} itemIds={filterIds}>
+                    {definition.filterFields.map((f) => (
+                        <SortableItem
+                            key={f.fieldName}
+                            id={f.fieldName}
+                            zone="filters"
+                            label={f.displayName ?? f.fieldName}
+                        >
+                            <button
+                                onClick={() => handleRemove(f.fieldName, 'filters')}
+                                onPointerDown={(e) => e.stopPropagation()}
+                                style={removeBtn}
+                            >
+                                ×
+                            </button>
+                        </SortableItem>
+                    ))}
+                </DroppableZone>
+
+                {/* Column zone */}
+                <DroppableZone id="columns" label={ZONE_LABELS.columns} itemIds={colIds}>
+                    {definition.colFields.map((f) => (
+                        <SortableItem
+                            key={f.fieldName}
+                            id={f.fieldName}
+                            zone="columns"
+                            label={f.displayName ?? f.fieldName}
+                        >
+                            <button
+                                onClick={() => handleRemove(f.fieldName, 'columns')}
+                                onPointerDown={(e) => e.stopPropagation()}
+                                style={removeBtn}
+                            >
+                                ×
+                            </button>
+                        </SortableItem>
+                    ))}
+                </DroppableZone>
+
+                {/* Row zone */}
+                <DroppableZone id="rows" label={ZONE_LABELS.rows} itemIds={rowIds}>
+                    {definition.rowFields.map((f) => (
+                        <SortableItem
+                            key={f.fieldName}
+                            id={f.fieldName}
+                            zone="rows"
+                            label={f.displayName ?? f.fieldName}
+                        >
+                            <button
+                                onClick={() => handleRemove(f.fieldName, 'rows')}
+                                onPointerDown={(e) => e.stopPropagation()}
+                                style={removeBtn}
+                            >
+                                ×
+                            </button>
+                        </SortableItem>
+                    ))}
+                </DroppableZone>
+
+                {/* Values zone */}
+                <DroppableZone id="values" label={ZONE_LABELS.values} itemIds={valueIds}>
+                    {definition.valueFields.map((f) => (
+                        <SortableItem
+                            key={f.fieldName}
+                            id={f.fieldName}
+                            zone="values"
+                            label={f.displayName ?? f.fieldName}
+                        >
+                            <select
+                                value={f.aggregation}
+                                onChange={(e) =>
+                                    handleAggChange(f.fieldName, e.target.value as AggregationType)
+                                }
+                                onClick={(e) => e.stopPropagation()}
+                                onPointerDown={(e) => e.stopPropagation()}
+                                style={{
+                                    fontSize: 10,
+                                    marginLeft: 4,
+                                    maxWidth: 60,
+                                    border: '1px solid #d1d5db',
+                                    borderRadius: 3,
+                                    padding: '1px 2px',
+                                    flexShrink: 0,
+                                }}
+                            >
+                                {AGG_OPTIONS.map((opt) => (
+                                    <option key={opt.value} value={opt.value}>
+                                        {opt.label}
+                                    </option>
+                                ))}
+                            </select>
+                            <button
+                                onClick={() => handleRemove(f.fieldName, 'values')}
+                                onPointerDown={(e) => e.stopPropagation()}
+                                style={removeBtn}
+                            >
+                                ×
+                            </button>
+                        </SortableItem>
+                    ))}
+                </DroppableZone>
+            </div>
+
+            <DragOverlay>
+                {activeId ? (
+                    <div
+                        style={{
+                            padding: '3px 10px',
+                            background: '#dbeafe',
+                            border: '1px solid #3b82f6',
+                            borderRadius: 4,
+                            fontSize: 12,
+                            boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                            cursor: 'grabbing',
+                            userSelect: 'none',
+                        }}
+                    >
+                        ⠿ {activeId}
+                    </div>
+                ) : null}
+            </DragOverlay>
+        </DndContext>
+    )
+}
+
+const removeBtn: React.CSSProperties = {
+    marginLeft: 4,
+    padding: '0 4px',
+    fontSize: 14,
+    lineHeight: 1,
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    color: '#6b7280',
+    flexShrink: 0,
+}

--- a/packages/frontend/src/core/pivot/PivotManager.ts
+++ b/packages/frontend/src/core/pivot/PivotManager.ts
@@ -1,0 +1,58 @@
+import type { CellData } from '@cellix/shared'
+import type { PivotDefinition } from './types'
+import { PivotEngine } from './PivotEngine'
+
+export class PivotManager {
+    private readonly pivots = new Map<string, PivotDefinition>()
+    private readonly listeners = new Set<() => void>()
+    private readonly engine = new PivotEngine()
+
+    createPivot(def: Omit<PivotDefinition, 'id'>): PivotDefinition {
+        const pivot: PivotDefinition = { ...def, id: crypto.randomUUID() }
+        this.pivots.set(pivot.id, pivot)
+        this._notify()
+        return pivot
+    }
+
+    updatePivot(id: string, patch: Partial<PivotDefinition>): void {
+        const existing = this.pivots.get(id)
+        if (!existing) return
+        this.pivots.set(id, { ...existing, ...patch })
+        this._notify()
+    }
+
+    deletePivot(id: string): void {
+        this.pivots.delete(id)
+        this._notify()
+    }
+
+    refreshPivot(
+        id: string,
+        getCell: (sheetId: string, row: number, col: number) => CellData | null,
+        setCell: (sheetId: string, row: number, col: number, data: CellData) => void,
+    ): void {
+        const def = this.pivots.get(id)
+        if (!def) return
+        const data = this.engine.calculate(def, getCell)
+        this.engine.writeToSheet(data, def, setCell)
+    }
+
+    getPivot(id: string): PivotDefinition | undefined {
+        return this.pivots.get(id)
+    }
+
+    getAllPivots(): PivotDefinition[] {
+        return [...this.pivots.values()]
+    }
+
+    subscribe(listener: () => void): () => void {
+        this.listeners.add(listener)
+        return () => this.listeners.delete(listener)
+    }
+
+    private _notify(): void {
+        this.listeners.forEach((fn) => fn())
+    }
+}
+
+export const pivotManager = new PivotManager()

--- a/packages/frontend/src/core/pivot/index.ts
+++ b/packages/frontend/src/core/pivot/index.ts
@@ -1,0 +1,5 @@
+export type { AggregationType, PivotField, PivotValueField, PivotDefinition } from './types'
+export { PivotEngine } from './PivotEngine'
+export { PivotManager, pivotManager } from './PivotManager'
+export { PivotFieldPanel } from './PivotFieldPanel'
+export type { PivotFieldPanelProps } from './PivotFieldPanel'

--- a/packages/frontend/src/core/pivot/types.ts
+++ b/packages/frontend/src/core/pivot/types.ts
@@ -1,0 +1,37 @@
+import type { CellRange } from '@cellix/shared'
+
+export type AggregationType =
+    | 'sum'
+    | 'count'
+    | 'average'
+    | 'max'
+    | 'min'
+    | 'countNumbers'
+    | 'product'
+
+export interface PivotField {
+    fieldName: string
+    displayName?: string
+}
+
+export interface PivotValueField extends PivotField {
+    aggregation: AggregationType
+    numberFormat?: string
+}
+
+export interface PivotDefinition {
+    id: string
+    name: string
+    sourceSheetId: string
+    sourceRange: CellRange
+    targetSheetId: string
+    targetStartRow: number
+    targetStartCol: number
+    rowFields: PivotField[]
+    colFields: PivotField[]
+    valueFields: PivotValueField[]
+    filterFields: PivotField[]
+    showRowGrandTotal: boolean
+    showColGrandTotal: boolean
+    showSubtotals: boolean
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,11 +40,16 @@ importers:
         specifier: ^5.4.5
         version: 5.9.3
 
+  packages/formula-engine/pkg: {}
+
   packages/frontend:
     dependencies:
       '@cellix/shared':
         specifier: workspace:*
         version: link:../shared
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -844,6 +849,9 @@ packages:
       supports-color:
         optional: true
 
+  echarts@6.0.0:
+    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
+
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
 
@@ -1117,6 +1125,9 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -1189,6 +1200,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zrender@6.0.0:
+    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
@@ -1754,6 +1768,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  echarts@6.0.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.0.0
+
   electron-to-chromium@1.5.340: {}
 
   end-of-stream@1.4.5:
@@ -2094,6 +2113,8 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  tslib@2.3.0: {}
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.7
@@ -2142,6 +2163,10 @@ snapshots:
   yallist@3.1.1: {}
 
   zod@3.25.76: {}
+
+  zrender@6.0.0:
+    dependencies:
+      tslib: 2.3.0
 
   zustand@5.0.12(@types/react@18.3.28)(react@18.3.1):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,15 @@ importers:
       '@cellix/shared':
         specifier: workspace:*
         version: link:../shared
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@18.3.1)
       echarts:
         specifier: ^6.0.0
         version: 6.0.0
@@ -172,6 +181,28 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1335,6 +1366,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.3.0
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.3.0
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      tslib: 2.3.0
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.3.0
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true


### PR DESCRIPTION
## Summary

- **Phase 6-1 — ECharts 차트 통합**: bar/line/pie/scatter/combo 5종 차트 지원, Canvas 위 절대 위치 오버레이 렌더링, 드래그 이동 및 리사이즈 핸들, 차트 삽입 다이얼로그, 수식 엔진 변경 시 자동 갱신
- **Phase 6-2 — 피벗 테이블 엔진**: 행/열 다차원 그룹핑, 집계 7종(sum·count·average·max·min·countNumbers·product), 계층 병합 헤더, `@dnd-kit` 기반 드래그 앤 드롭 필드 패널

## New Files

| 파일 | 역할 |
|------|------|
| `core/chart/ChartManager.ts` | 차트 CRUD + 위치 조회 + 구독 싱글톤 |
| `core/chart/ChartDataMapper.ts` | 셀 범위 → EChartsOption 변환 |
| `core/chart/types.ts` | ChartDefinition 타입 |
| `components/ChartOverlay.tsx` | Canvas 위 ECharts 렌더링 + 드래그/리사이즈 |
| `components/dialogs/ChartInsertDialog.tsx` | 차트 삽입 다이얼로그 |
| `core/pivot/PivotEngine.ts` | 소스 범위 → 그룹핑 + 집계 계산 |
| `core/pivot/PivotManager.ts` | 피벗 CRUD + refreshPivot() 싱글톤 |
| `core/pivot/PivotFieldPanel.tsx` | 필터·열·행·값 4구역 드래그 앤 드롭 UI |
| `core/pivot/types.ts` | PivotDefinition, PivotField 타입 |

## Changed Files

| 파일 | 변경 내용 |
|------|---------|
| `components/GridCanvas.tsx` | viewportRef 노출, 차트 자동 갱신 연결 |
| `components/Toolbar.tsx` | 📊 차트 삽입 버튼 연결 |
| `frontend/package.json` | echarts, @dnd-kit/core, @dnd-kit/sortable 추가 |

## Test Plan

- [ ] Toolbar의 📊 버튼 클릭 → ChartInsertDialog 열림
- [ ] 범위 선택 후 차트 삽입 → Canvas 위에 차트 렌더링
- [ ] 차트 드래그 이동 / 우하단 핸들 리사이즈 동작
- [ ] 소스 셀 값 변경 → 차트 자동 갱신
- [ ] PivotFieldPanel에서 필드 드래그 앤 드롭 → 피벗 테이블 시트에 기록
- [ ] 집계 함수(sum·count·average 등) 변경 → 값 즉시 갱신
- [ ] TypeScript 타입 에러 없음 (`pnpm typecheck`)