### PR TITLE
feat: Phase 8 — 채점 엔진 · 문제 풀이 UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,10 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
+# WASM build outputs
+packages/formula-engine/pkg/
+packages/formula-engine/pkg-node/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ PostgreSQL: 5432
 Redis:      6379
 ```
 
+WASM 빌드 타겟:
+pkg/ → --target web (브라우저, Web Worker에서 사용)
+pkg-node/ → --target nodejs (Node.js 백엔드 채점 서비스에서 사용)
+
+두 타겟 모두 동일한 Rust 소스에서 빌드되므로 수식 계산 결과가 완벽히 동일.
+
 ---
 
 ## 2. 모노레포 구조
@@ -475,6 +481,25 @@ await formulaEngine.registerTable(
     }),
 );
 ```
+
+### Node.js에서 WASM 사용 (백엔드)
+
+Node.js 타겟은 init() 없이 바로 사용 가능:
+
+// ✅ 올바름 — Node.js에서는 동기 로드
+import { FormulaEngine } from 'formula-engine-node'
+const engine = new FormulaEngine() // init() 불필요
+engine.add_sheet('s1', 'Sheet1')
+
+// ❌ 금지 — 백엔드에서 HyperFormula 사용
+import HyperFormula from 'hyperformula' // 사용 금지, 결과 불일치 위험
+
+### 채점 시 주의사항
+
+grading.service.ts 에서:
+
+- FormulaEngine 인스턴스는 요청마다 새로 생성 (싱글톤 X — 상태 격리 필요)
+- batch_set()으로 한번에 로드 (셀마다 set_cell() 반복 X — 성능)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "build:wasm": "cd packages/formula-engine && wasm-pack build --target web --out-dir pkg --release",
-        "build:wasm:dev": "cd packages/formula-engine && wasm-pack build --target web --out-dir pkg --dev",
+        "build:wasm": "cd packages/formula-engine && wasm-pack build --target web --out-dir pkg --release && wasm-pack build --target nodejs --out-dir pkg-node --release",
+        "build:wasm:dev": "cd packages/formula-engine && wasm-pack build --target web --out-dir pkg --dev && wasm-pack build --target nodejs --out-dir pkg-node --dev",
         "dev": "pnpm build:wasm:dev && pnpm --parallel -r dev",
         "build": "pnpm -r build",
         "typecheck": "pnpm -r typecheck",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,7 @@
         "drizzle-orm": "^0.45.2",
         "fastify": "^4.28.1",
         "fastify-plugin": "^5.1.0",
+        "hyperformula": "^3.2.0",
         "pino-pretty": "^13.1.3",
         "postgres": "^3.4.9",
         "xlsx": "^0.18.5",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -16,6 +16,7 @@
     },
     "dependencies": {
         "@cellix/shared": "workspace:*",
+        "formula-engine-node": "workspace:*",
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^9.0.1",
         "@fastify/jwt": "^10.0.0",

--- a/packages/backend/src/routes/submissions.routes.ts
+++ b/packages/backend/src/routes/submissions.routes.ts
@@ -1,7 +1,11 @@
 import type { FastifyPluginAsync } from 'fastify'
 import { z } from 'zod'
-import { eq, and } from 'drizzle-orm'
-import { submissions, userProgress } from '../db/schema.js'
+import { eq, and, sql, count, desc } from 'drizzle-orm'
+import { submissions, userProgress, problems } from '../db/schema.js'
+import { deserializeWorkbook } from '@cellix/shared'
+import type { SerializedWorkbookData } from '@cellix/shared'
+import { gradingService } from '../services/grading.service.js'
+import type { GradingConfig } from '../services/grading.service.js'
 
 const SubmitBody = z.object({
     problemId: z.string().uuid(),
@@ -9,39 +13,72 @@ const SubmitBody = z.object({
     timeSpentSeconds: z.number().int().min(0).optional(),
 })
 
+const PaginationQuery = z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(50).default(10),
+})
+
+const EMPTY_WORKBOOK: SerializedWorkbookData = {
+    id: '', name: '', sheets: {}, sheetOrder: [], activeSheetId: '', createdAt: '', updatedAt: '',
+}
+
 export const submissionRoutes: FastifyPluginAsync = async (app) => {
-    app.get('/my', { preHandler: [app.authenticate] }, async (request) => {
-        const rows = await app.db.query.submissions.findMany({
-            where: eq(submissions.userId, request.userId),
-        })
-        return { success: true, data: rows }
-    })
-
-    app.get('/:id', { preHandler: [app.authenticate] }, async (request, reply) => {
-        const { id } = request.params as { id: string }
-        const row = await app.db.query.submissions.findFirst({
-            where: eq(submissions.id, id),
-        })
-        if (!row) return reply.status(404).send({ success: false, error: 'Not found', code: 'NOT_FOUND' })
-        if (row.userId !== request.userId && request.userRole !== 'admin') {
-            return reply.status(403).send({ success: false, error: 'Forbidden', code: 'FORBIDDEN' })
-        }
-        return { success: true, data: row }
-    })
-
+    // ── 제출 + 즉시 채점 ────────────────────────────────────────────────────────
     app.post('/', { preHandler: [app.authenticate] }, async (request, reply) => {
         const body = SubmitBody.parse(request.body)
+
+        // 문제 조회 (answerWorkbook, gradingConfig 포함)
+        const problem = await app.db.query.problems.findFirst({
+            where: eq(problems.id, body.problemId),
+        })
+        if (!problem) {
+            return reply.status(404).send({ success: false, error: 'Problem not found', code: 'NOT_FOUND' })
+        }
+
+        // 워크북 역직렬화
+        const submittedWb = deserializeWorkbook(
+            (body.submittedWorkbook as SerializedWorkbookData) ?? EMPTY_WORKBOOK,
+        )
+        const answerWb = deserializeWorkbook(
+            (problem.answerWorkbook as unknown as SerializedWorkbookData) ?? EMPTY_WORKBOOK,
+        )
+        const config = (problem.gradingConfig as unknown as GradingConfig)
+
+        // 채점
+        let gradingResult
+        let submissionStatus: 'graded' | 'error' = 'graded'
+        try {
+            gradingResult = await gradingService.grade(submittedWb, answerWb, config)
+        } catch (err) {
+            app.log.error({ err }, 'Grading failed')
+            gradingResult = {
+                totalScore: 0,
+                maxScore: config?.totalScore ?? 0,
+                percentage: 0,
+                status: 'fail' as const,
+                cellResults: [],
+                feedback: '채점 중 오류가 발생했습니다.',
+            }
+            submissionStatus = 'error'
+        }
+
+        // DB 저장
         const [row] = await app.db
             .insert(submissions)
             .values({
                 userId: request.userId,
                 problemId: body.problemId,
                 submittedWorkbook: body.submittedWorkbook as Record<string, unknown>,
+                totalScore: String(gradingResult.totalScore),
+                maxScore: gradingResult.maxScore,
+                percentage: String(gradingResult.percentage),
+                status: submissionStatus,
+                feedback: gradingResult as unknown as Record<string, unknown>,
                 timeSpentSeconds: body.timeSpentSeconds,
             })
             .returning()
 
-        // 진행 상황 upsert
+        // userProgress upsert (best_score 갱신)
         const existing = await app.db.query.userProgress.findFirst({
             where: and(
                 eq(userProgress.userId, request.userId),
@@ -49,9 +86,16 @@ export const submissionRoutes: FastifyPluginAsync = async (app) => {
             ),
         })
         if (existing) {
+            const prevBest = parseFloat(existing.bestScore ?? '0')
             await app.db
                 .update(userProgress)
-                .set({ attempts: existing.attempts + 1, lastAttemptAt: new Date() })
+                .set({
+                    attempts: existing.attempts + 1,
+                    lastAttemptAt: new Date(),
+                    bestScore: gradingResult.totalScore > prevBest
+                        ? String(gradingResult.totalScore)
+                        : existing.bestScore,
+                })
                 .where(
                     and(
                         eq(userProgress.userId, request.userId),
@@ -64,9 +108,71 @@ export const submissionRoutes: FastifyPluginAsync = async (app) => {
                 problemId: body.problemId,
                 attempts: 1,
                 lastAttemptAt: new Date(),
+                bestScore: String(gradingResult.totalScore),
             })
         }
 
-        return reply.status(201).send({ success: true, data: row })
+        return reply.status(201).send({
+            success: true,
+            data: { submission: row, result: gradingResult },
+        })
+    })
+
+    // ── 제출 단건 조회 ────────────────────────────────────────────────────────────
+    app.get('/:id', { preHandler: [app.authenticate] }, async (request, reply) => {
+        const { id } = request.params as { id: string }
+        const row = await app.db.query.submissions.findFirst({
+            where: eq(submissions.id, id),
+        })
+        if (!row) return reply.status(404).send({ success: false, error: 'Not found', code: 'NOT_FOUND' })
+        if (row.userId !== request.userId && request.userRole !== 'admin') {
+            return reply.status(403).send({ success: false, error: 'Forbidden', code: 'FORBIDDEN' })
+        }
+        return { success: true, data: row }
+    })
+
+    // ── 내 제출 목록 ─────────────────────────────────────────────────────────────
+    app.get('/me', { preHandler: [app.authenticate] }, async (request) => {
+        const query = PaginationQuery.parse(request.query)
+        const offset = (query.page - 1) * query.limit
+        const rows = await app.db
+            .select()
+            .from(submissions)
+            .where(eq(submissions.userId, request.userId))
+            .orderBy(desc(submissions.submittedAt))
+            .limit(query.limit)
+            .offset(offset)
+        return { success: true, data: rows }
+    })
+
+    // ── 문제별 통계 [admin] ───────────────────────────────────────────────────────
+    app.get('/problem/:problemId/stats', { preHandler: [app.authenticate] }, async (request, reply) => {
+        if (request.userRole !== 'admin') {
+            return reply.status(403).send({ success: false, error: 'Forbidden', code: 'FORBIDDEN' })
+        }
+        const { problemId } = request.params as { problemId: string }
+
+        const [stats] = await app.db
+            .select({
+                total: count(),
+                avgPercentage: sql<string | null>`avg(${submissions.percentage}::numeric)`,
+                passCount: sql<number>`coalesce(sum(case when ${submissions.percentage}::numeric >= 100 then 1 else 0 end), 0)::int`,
+            })
+            .from(submissions)
+            .where(eq(submissions.problemId, problemId))
+
+        const total = stats.total
+        const passCount = stats.passCount ?? 0
+        const avgPct = stats.avgPercentage ? parseFloat(stats.avgPercentage) : 0
+
+        return {
+            success: true,
+            data: {
+                total,
+                avgPercentage: Math.round(avgPct * 100) / 100,
+                passCount,
+                passRate: total > 0 ? Math.round((passCount / total) * 10000) / 100 : 0,
+            },
+        }
     })
 }

--- a/packages/backend/src/routes/submissions.routes.ts
+++ b/packages/backend/src/routes/submissions.routes.ts
@@ -2,14 +2,12 @@ import type { FastifyPluginAsync } from 'fastify'
 import { z } from 'zod'
 import { eq, and, sql, count, desc } from 'drizzle-orm'
 import { submissions, userProgress, problems } from '../db/schema.js'
-import { deserializeWorkbook } from '@cellix/shared'
-import type { SerializedWorkbookData } from '@cellix/shared'
 import { gradingService } from '../services/grading.service.js'
 import type { GradingConfig } from '../services/grading.service.js'
 
 const SubmitBody = z.object({
     problemId: z.string().uuid(),
-    submittedWorkbook: z.unknown(),
+    workbookData: z.unknown(),
     timeSpentSeconds: z.number().int().min(0).optional(),
 })
 
@@ -17,10 +15,6 @@ const PaginationQuery = z.object({
     page: z.coerce.number().int().min(1).default(1),
     limit: z.coerce.number().int().min(1).max(50).default(10),
 })
-
-const EMPTY_WORKBOOK: SerializedWorkbookData = {
-    id: '', name: '', sheets: {}, sheetOrder: [], activeSheetId: '', createdAt: '', updatedAt: '',
-}
 
 export const submissionRoutes: FastifyPluginAsync = async (app) => {
     // ── 제출 + 즉시 채점 ────────────────────────────────────────────────────────
@@ -35,20 +29,13 @@ export const submissionRoutes: FastifyPluginAsync = async (app) => {
             return reply.status(404).send({ success: false, error: 'Problem not found', code: 'NOT_FOUND' })
         }
 
-        // 워크북 역직렬화
-        const submittedWb = deserializeWorkbook(
-            (body.submittedWorkbook as SerializedWorkbookData) ?? EMPTY_WORKBOOK,
-        )
-        const answerWb = deserializeWorkbook(
-            (problem.answerWorkbook as unknown as SerializedWorkbookData) ?? EMPTY_WORKBOOK,
-        )
         const config = (problem.gradingConfig as unknown as GradingConfig)
 
-        // 채점
+        // 채점 (deserializeWorkbook은 grading.service 내부에서 호출)
         let gradingResult
         let submissionStatus: 'graded' | 'error' = 'graded'
         try {
-            gradingResult = await gradingService.grade(submittedWb, answerWb, config)
+            gradingResult = await gradingService.grade(body.workbookData, config)
         } catch (err) {
             app.log.error({ err }, 'Grading failed')
             gradingResult = {
@@ -57,6 +44,7 @@ export const submissionRoutes: FastifyPluginAsync = async (app) => {
                 percentage: 0,
                 status: 'fail' as const,
                 cellResults: [],
+                tableResults: [],
                 feedback: '채점 중 오류가 발생했습니다.',
             }
             submissionStatus = 'error'
@@ -68,7 +56,7 @@ export const submissionRoutes: FastifyPluginAsync = async (app) => {
             .values({
                 userId: request.userId,
                 problemId: body.problemId,
-                submittedWorkbook: body.submittedWorkbook as Record<string, unknown>,
+                submittedWorkbook: body.workbookData as Record<string, unknown>,
                 totalScore: String(gradingResult.totalScore),
                 maxScore: gradingResult.maxScore,
                 percentage: String(gradingResult.percentage),

--- a/packages/backend/src/services/grading.service.ts
+++ b/packages/backend/src/services/grading.service.ts
@@ -1,6 +1,207 @@
-// Phase 8에서 구현 예정
-export const gradingService = {
-    async grade(_submissionId: string): Promise<void> {
-        throw new Error('Not implemented — Phase 8')
-    },
+import { HyperFormula } from 'hyperformula'
+import type { WorkbookData } from '@cellix/shared'
+
+// ── 채점 설정 타입 ─────────────────────────────────────────────────────────────
+
+export interface GradingConfig {
+    cells?: CellGradingRule[]
+    tables?: TableGradingRule[]
+    charts?: ChartGradingRule[]
+    totalScore: number
 }
+
+export interface CellGradingRule {
+    sheetId: string        // HyperFormula에서 사용하는 시트 이름
+    address: string        // "A1" 형식
+    expectedValue?: unknown
+    tolerance?: number     // 숫자 허용 오차 (기본 0.001)
+    checkFormula?: boolean
+    formulaPattern?: string  // 정규식 패턴
+    scoreWeight: number
+}
+
+export interface TableGradingRule {
+    name: string
+    checkColumns?: boolean
+    scoreWeight: number
+}
+
+export interface ChartGradingRule {
+    type?: string
+    scoreWeight: number
+}
+
+// ── 채점 결과 타입 ─────────────────────────────────────────────────────────────
+
+export interface GradingResult {
+    totalScore: number
+    maxScore: number
+    percentage: number
+    status: 'pass' | 'partial' | 'fail'
+    cellResults: CellRuleResult[]
+    feedback: string
+}
+
+export interface CellRuleResult {
+    address: string
+    sheetId: string
+    passed: boolean
+    earnedScore: number
+    maxScore: number
+    actualValue?: unknown
+    expectedValue?: unknown
+    formulaMatched?: boolean
+    hint?: string
+}
+
+// ── GradingService ─────────────────────────────────────────────────────────────
+
+export class GradingService {
+    async grade(
+        submittedWorkbook: WorkbookData,
+        _answerWorkbook: WorkbookData,
+        config: GradingConfig,
+    ): Promise<GradingResult> {
+        const hf = HyperFormula.buildFromSheets(
+            this._workbookToHFSheets(submittedWorkbook),
+            { licenseKey: 'gpl-v3' },
+        )
+
+        const results: CellRuleResult[] = []
+        let totalEarned = 0
+
+        for (const rule of config.cells ?? []) {
+            const result = this._gradeCellRule(hf, rule)
+            results.push(result)
+            totalEarned += result.earnedScore
+        }
+
+        for (const rule of config.tables ?? []) {
+            const result = this._gradeTableRule(submittedWorkbook, rule)
+            results.push({ ...result, address: `Table:${rule.name}`, sheetId: '' })
+            totalEarned += result.earnedScore
+        }
+
+        const maxScore = config.totalScore
+        const pct = maxScore > 0 ? (totalEarned / maxScore) * 100 : 0
+
+        return {
+            totalScore: totalEarned,
+            maxScore,
+            percentage: Math.round(pct * 100) / 100,
+            status: pct >= 100 ? 'pass' : pct > 0 ? 'partial' : 'fail',
+            cellResults: results,
+            feedback: this._buildFeedback(results, pct),
+        }
+    }
+
+    private _gradeCellRule(hf: HyperFormula, rule: CellGradingRule): CellRuleResult {
+        const { row, col } = this._parseAddress(rule.address)
+        const hfSheetIdx = hf.getSheetId(rule.sheetId)
+
+        if (hfSheetIdx === undefined) {
+            return {
+                address: rule.address,
+                sheetId: rule.sheetId,
+                passed: false,
+                earnedScore: 0,
+                maxScore: rule.scoreWeight,
+                hint: `시트를 찾을 수 없음: ${rule.sheetId}`,
+            }
+        }
+
+        const addr = { sheet: hfSheetIdx, row, col }
+        const raw = hf.getCellValue(addr)
+        // DetailedCellError is an object — convert to string for comparison
+        const actualValue: string | number | boolean | null =
+            raw !== null && raw !== undefined && typeof raw === 'object'
+                ? String(raw)
+                : (raw ?? null)
+
+        // 수식 패턴 검사
+        let formulaMatched: boolean | undefined
+        if (rule.checkFormula) {
+            const formula = hf.getCellFormula(addr)
+            if (rule.formulaPattern) {
+                formulaMatched = formula ? new RegExp(rule.formulaPattern, 'i').test(formula) : false
+            } else {
+                formulaMatched = !!formula
+            }
+        }
+
+        // 값 비교
+        let passed = true
+        if (rule.expectedValue !== undefined && rule.expectedValue !== null) {
+            const expected = rule.expectedValue
+            if (typeof expected === 'number' && typeof actualValue === 'number') {
+                passed = Math.abs(actualValue - expected) <= (rule.tolerance ?? 0.001)
+            } else {
+                passed = String(actualValue) === String(expected)
+            }
+        }
+
+        // 수식 검사 (AND 조건)
+        if (rule.checkFormula && formulaMatched !== undefined) {
+            passed = passed && formulaMatched
+        }
+
+        return {
+            address: rule.address,
+            sheetId: rule.sheetId,
+            passed,
+            earnedScore: passed ? rule.scoreWeight : 0,
+            maxScore: rule.scoreWeight,
+            actualValue,
+            expectedValue: rule.expectedValue,
+            formulaMatched,
+            hint: passed ? undefined : `예상값: ${rule.expectedValue}, 실제값: ${actualValue}`,
+        }
+    }
+
+    private _gradeTableRule(
+        submitted: WorkbookData,
+        rule: TableGradingRule,
+    ): Pick<CellRuleResult, 'passed' | 'earnedScore' | 'maxScore' | 'hint'> {
+        // 모든 시트 cells에서 표 이름 키를 검색하는 간단 구현
+        // (표 메타데이터가 workbook JSON에 포함되면 실제 검증 가능)
+        void submitted
+        return {
+            passed: true,
+            earnedScore: rule.scoreWeight,
+            maxScore: rule.scoreWeight,
+        }
+    }
+
+    private _workbookToHFSheets(wb: WorkbookData): Record<string, (string | number | boolean | null)[][]> {
+        const result: Record<string, (string | number | boolean | null)[][]> = {}
+        for (const sheet of wb.sheets.values()) {
+            const grid: (string | number | boolean | null)[][] = []
+            for (const [key, cell] of sheet.cells) {
+                const [rStr, cStr] = key.split(':')
+                const r = parseInt(rStr)
+                const c = parseInt(cStr)
+                if (!grid[r]) grid[r] = []
+                grid[r][c] = cell.formula ? cell.formula : (cell.value ?? null)
+            }
+            result[sheet.name] = grid
+        }
+        return result
+    }
+
+    private _parseAddress(addr: string): { row: number; col: number } {
+        const match = addr.match(/^(\$?)([A-Z]+)(\$?)(\d+)$/)
+        if (!match) return { row: 0, col: 0 }
+        const col = match[2].split('').reduce((acc, ch) => acc * 26 + (ch.charCodeAt(0) - 64), 0) - 1
+        const row = parseInt(match[4]) - 1
+        return { row, col }
+    }
+
+    private _buildFeedback(results: CellRuleResult[], pct: number): string {
+        if (pct >= 100) return '완벽합니다! 모든 항목을 정확하게 완성했습니다.'
+        const failed = results.filter(r => !r.passed)
+        if (failed.length === 0) return '훌륭합니다!'
+        return `${failed.length}개 항목이 틀렸습니다. 다시 확인해보세요.`
+    }
+}
+
+export const gradingService = new GradingService()

--- a/packages/backend/src/services/grading.service.ts
+++ b/packages/backend/src/services/grading.service.ts
@@ -1,7 +1,37 @@
-import { HyperFormula } from 'hyperformula'
-import type { WorkbookData } from '@cellix/shared'
+import { createRequire } from 'node:module'
+import type { FormulaEngine as IFormulaEngine } from 'formula-engine-node'
+import type { WorkbookData, CellValue } from '@cellix/shared'
+import { deserializeWorkbook } from '@cellix/shared'
 
-// ── 채점 설정 타입 ─────────────────────────────────────────────────────────────
+const _require = createRequire(import.meta.url)
+const { FormulaEngine } = _require('formula-engine-node') as { FormulaEngine: new () => IFormulaEngine }
+
+// ── 채점 설정 타입 ─────────────────────────────────────────────────────────
+
+export interface CellGradingRule {
+    sheetId: string
+    address: string
+    expectedValue?: CellValue
+    tolerance?: number
+    checkFormula?: boolean
+    formulaPattern?: string
+    scoreWeight: number
+    hint?: string
+}
+
+export interface TableGradingRule {
+    name: string
+    checkColumns?: boolean
+    expectedColumns?: string[]
+    scoreWeight: number
+    hint?: string
+}
+
+export interface ChartGradingRule {
+    expectedType?: string
+    scoreWeight: number
+    hint?: string
+}
 
 export interface GradingConfig {
     cells?: CellGradingRule[]
@@ -10,28 +40,18 @@ export interface GradingConfig {
     totalScore: number
 }
 
-export interface CellGradingRule {
-    sheetId: string        // HyperFormula에서 사용하는 시트 이름
-    address: string        // "A1" 형식
-    expectedValue?: unknown
-    tolerance?: number     // 숫자 허용 오차 (기본 0.001)
-    checkFormula?: boolean
-    formulaPattern?: string  // 정규식 패턴
-    scoreWeight: number
+export interface CellRuleResult {
+    address: string
+    sheetId: string
+    passed: boolean
+    earnedScore: number
+    maxScore: number
+    actualValue?: CellValue
+    expectedValue?: CellValue
+    formulaUsed?: string
+    formulaMatched?: boolean
+    hint?: string
 }
-
-export interface TableGradingRule {
-    name: string
-    checkColumns?: boolean
-    scoreWeight: number
-}
-
-export interface ChartGradingRule {
-    type?: string
-    scoreWeight: number
-}
-
-// ── 채점 결과 타입 ─────────────────────────────────────────────────────────────
 
 export interface GradingResult {
     totalScore: number
@@ -39,111 +59,146 @@ export interface GradingResult {
     percentage: number
     status: 'pass' | 'partial' | 'fail'
     cellResults: CellRuleResult[]
+    tableResults: { name: string; passed: boolean; earnedScore: number; maxScore: number; hint?: string }[]
     feedback: string
 }
 
-export interface CellRuleResult {
-    address: string
-    sheetId: string
-    passed: boolean
-    earnedScore: number
-    maxScore: number
-    actualValue?: unknown
-    expectedValue?: unknown
-    formulaMatched?: boolean
-    hint?: string
-}
-
-// ── GradingService ─────────────────────────────────────────────────────────────
+// ── 채점 서비스 ────────────────────────────────────────────────────────────
 
 export class GradingService {
-    async grade(
-        submittedWorkbook: WorkbookData,
-        _answerWorkbook: WorkbookData,
-        config: GradingConfig,
-    ): Promise<GradingResult> {
-        const hf = HyperFormula.buildFromSheets(
-            this._workbookToHFSheets(submittedWorkbook),
-            { licenseKey: 'gpl-v3' },
-        )
+    async grade(submittedRaw: unknown, config: GradingConfig): Promise<GradingResult> {
+        const workbook = deserializeWorkbook(submittedRaw)
 
-        const results: CellRuleResult[] = []
+        // 요청마다 새 인스턴스 (상태 격리)
+        const engine = new FormulaEngine()
+        this._loadWorkbookIntoEngine(engine, workbook)
+
+        const cellResults: CellRuleResult[] = []
         let totalEarned = 0
 
         for (const rule of config.cells ?? []) {
-            const result = this._gradeCellRule(hf, rule)
-            results.push(result)
+            const result = this._gradeCellRule(engine, rule)
+            cellResults.push(result)
             totalEarned += result.earnedScore
         }
 
+        const tableResults: GradingResult['tableResults'] = []
         for (const rule of config.tables ?? []) {
-            const result = this._gradeTableRule(submittedWorkbook, rule)
-            results.push({ ...result, address: `Table:${rule.name}`, sheetId: '' })
+            const result = this._gradeTableRule(workbook, rule)
+            tableResults.push(result)
             totalEarned += result.earnedScore
         }
 
         const maxScore = config.totalScore
-        const pct = maxScore > 0 ? (totalEarned / maxScore) * 100 : 0
+        const percentage = maxScore > 0
+            ? Math.round((totalEarned / maxScore) * 10000) / 100
+            : 0
+
+        const status: GradingResult['status'] =
+            percentage >= 100 ? 'pass' : percentage > 0 ? 'partial' : 'fail'
 
         return {
-            totalScore: totalEarned,
+            totalScore: Math.round(totalEarned * 100) / 100,
             maxScore,
-            percentage: Math.round(pct * 100) / 100,
-            status: pct >= 100 ? 'pass' : pct > 0 ? 'partial' : 'fail',
-            cellResults: results,
-            feedback: this._buildFeedback(results, pct),
+            percentage,
+            status,
+            cellResults,
+            tableResults,
+            feedback: this._buildFeedback(cellResults, tableResults, percentage),
         }
     }
 
-    private _gradeCellRule(hf: HyperFormula, rule: CellGradingRule): CellRuleResult {
-        const { row, col } = this._parseAddress(rule.address)
-        const hfSheetIdx = hf.getSheetId(rule.sheetId)
+    // ── 워크북 → WASM 엔진 로드 ─────────────────────────────────────────────
 
-        if (hfSheetIdx === undefined) {
+    private _loadWorkbookIntoEngine(engine: IFormulaEngine, workbook: WorkbookData): void {
+        for (const sheetId of workbook.sheetOrder) {
+            const sheet = workbook.sheets.get(sheetId)
+            if (!sheet) continue
+
+            engine.add_sheet(sheetId, sheet.name)
+
+            const updates: Array<{
+                sheet_id: string
+                row: number
+                col: number
+                data: { value: CellValue; formula?: string }
+            }> = []
+
+            for (const [key, cellData] of sheet.cells) {
+                const [rowStr, colStr] = key.split(':')
+                const row = parseInt(rowStr, 10)
+                const col = parseInt(colStr, 10)
+                if (isNaN(row) || isNaN(col)) continue
+                updates.push({
+                    sheet_id: sheetId,
+                    row,
+                    col,
+                    data: { value: cellData.value, formula: cellData.formula },
+                })
+            }
+
+            if (updates.length > 0) {
+                engine.batch_set(JSON.stringify(updates))
+            }
+        }
+
+        if (workbook.activeSheetId) {
+            engine.set_active_sheet(workbook.activeSheetId)
+        }
+    }
+
+    // ── 셀 채점 ──────────────────────────────────────────────────────────────
+
+    private _gradeCellRule(engine: IFormulaEngine, rule: CellGradingRule): CellRuleResult {
+        const { row, col } = this._parseAddress(rule.address)
+
+        const rawJson = engine.get_cell_value(rule.sheetId, row, col)
+        const parsed = this._parseCellVal(rawJson)
+        const actualValue = this._toValue(parsed)
+
+        const formulaUsed = engine.get_cell_formula(rule.sheetId, row, col) ?? undefined
+
+        let formulaMatched: boolean | undefined
+        if (rule.checkFormula && rule.formulaPattern) {
+            if (!formulaUsed) {
+                formulaMatched = false
+            } else {
+                try {
+                    formulaMatched = new RegExp(rule.formulaPattern, 'i').test(formulaUsed)
+                } catch {
+                    formulaMatched = false
+                }
+            }
+        }
+
+        // 에러 셀 자동 실패
+        if (parsed?.t === 'e') {
             return {
                 address: rule.address,
                 sheetId: rule.sheetId,
                 passed: false,
                 earnedScore: 0,
                 maxScore: rule.scoreWeight,
-                hint: `시트를 찾을 수 없음: ${rule.sheetId}`,
+                actualValue: String(parsed.v ?? '#ERROR'),
+                expectedValue: rule.expectedValue,
+                formulaUsed,
+                formulaMatched,
+                hint: rule.hint ?? `셀에 오류가 있습니다: ${parsed.v}`,
             }
         }
 
-        const addr = { sheet: hfSheetIdx, row, col }
-        const raw = hf.getCellValue(addr)
-        // DetailedCellError is an object — convert to string for comparison
-        const actualValue: string | number | boolean | null =
-            raw !== null && raw !== undefined && typeof raw === 'object'
-                ? String(raw)
-                : (raw ?? null)
-
-        // 수식 패턴 검사
-        let formulaMatched: boolean | undefined
-        if (rule.checkFormula) {
-            const formula = hf.getCellFormula(addr)
-            if (rule.formulaPattern) {
-                formulaMatched = formula ? new RegExp(rule.formulaPattern, 'i').test(formula) : false
-            } else {
-                formulaMatched = !!formula
-            }
+        let valuePassed = false
+        if (rule.expectedValue === undefined || rule.expectedValue === null) {
+            valuePassed = true
+        } else if (typeof rule.expectedValue === 'number' && typeof actualValue === 'number') {
+            valuePassed = Math.abs(actualValue - rule.expectedValue) <= (rule.tolerance ?? 0.001)
+        } else if (typeof rule.expectedValue === 'boolean') {
+            valuePassed = actualValue === rule.expectedValue
+        } else {
+            valuePassed = String(actualValue ?? '').trim() === String(rule.expectedValue).trim()
         }
 
-        // 값 비교
-        let passed = true
-        if (rule.expectedValue !== undefined && rule.expectedValue !== null) {
-            const expected = rule.expectedValue
-            if (typeof expected === 'number' && typeof actualValue === 'number') {
-                passed = Math.abs(actualValue - expected) <= (rule.tolerance ?? 0.001)
-            } else {
-                passed = String(actualValue) === String(expected)
-            }
-        }
-
-        // 수식 검사 (AND 조건)
-        if (rule.checkFormula && formulaMatched !== undefined) {
-            passed = passed && formulaMatched
-        }
+        const passed = valuePassed && (rule.checkFormula ? formulaMatched !== false : true)
 
         return {
             address: rule.address,
@@ -153,54 +208,111 @@ export class GradingService {
             maxScore: rule.scoreWeight,
             actualValue,
             expectedValue: rule.expectedValue,
+            formulaUsed,
             formulaMatched,
-            hint: passed ? undefined : `예상값: ${rule.expectedValue}, 실제값: ${actualValue}`,
+            hint: passed ? undefined : (rule.hint ?? this._buildCellHint(rule, actualValue, formulaUsed, formulaMatched)),
         }
     }
 
-    private _gradeTableRule(
-        submitted: WorkbookData,
-        rule: TableGradingRule,
-    ): Pick<CellRuleResult, 'passed' | 'earnedScore' | 'maxScore' | 'hint'> {
-        // 모든 시트 cells에서 표 이름 키를 검색하는 간단 구현
-        // (표 메타데이터가 workbook JSON에 포함되면 실제 검증 가능)
-        void submitted
-        return {
-            passed: true,
-            earnedScore: rule.scoreWeight,
-            maxScore: rule.scoreWeight,
-        }
-    }
+    // ── 표 채점 ──────────────────────────────────────────────────────────────
 
-    private _workbookToHFSheets(wb: WorkbookData): Record<string, (string | number | boolean | null)[][]> {
-        const result: Record<string, (string | number | boolean | null)[][]> = {}
-        for (const sheet of wb.sheets.values()) {
-            const grid: (string | number | boolean | null)[][] = []
-            for (const [key, cell] of sheet.cells) {
-                const [rStr, cStr] = key.split(':')
-                const r = parseInt(rStr)
-                const c = parseInt(cStr)
-                if (!grid[r]) grid[r] = []
-                grid[r][c] = cell.formula ? cell.formula : (cell.value ?? null)
+    private _gradeTableRule(workbook: WorkbookData, rule: TableGradingRule): GradingResult['tableResults'][number] {
+        const raw = workbook as unknown as Record<string, unknown>
+        const tables: unknown[] = Array.isArray(raw['tables']) ? raw['tables'] as unknown[] : []
+        const found = tables.find((t): t is Record<string, unknown> =>
+            typeof t === 'object' && t !== null && (t as Record<string, unknown>)['name'] === rule.name
+        )
+
+        if (!found) {
+            return {
+                name: rule.name,
+                passed: false,
+                earnedScore: 0,
+                maxScore: rule.scoreWeight,
+                hint: rule.hint ?? `"${rule.name}" 이름의 표가 없습니다.`,
             }
-            result[sheet.name] = grid
         }
-        return result
+
+        if (rule.checkColumns && rule.expectedColumns) {
+            const actualColumns = Array.isArray(found['columns'])
+                ? (found['columns'] as unknown[]).map(String)
+                : []
+            const colsPassed = rule.expectedColumns.every(
+                (expected, i) => actualColumns[i]?.trim() === expected.trim(),
+            )
+            if (!colsPassed) {
+                return {
+                    name: rule.name,
+                    passed: false,
+                    earnedScore: 0,
+                    maxScore: rule.scoreWeight,
+                    hint: rule.hint ?? `표 컬럼 헤더가 올바르지 않습니다. 예상: [${rule.expectedColumns.join(', ')}]`,
+                }
+            }
+        }
+
+        return { name: rule.name, passed: true, earnedScore: rule.scoreWeight, maxScore: rule.scoreWeight }
     }
 
+    // ── 유틸 ─────────────────────────────────────────────────────────────────
+
+    /** "A1" | "$B$2" → { row: 0, col: 0 } (0-based) */
     private _parseAddress(addr: string): { row: number; col: number } {
-        const match = addr.match(/^(\$?)([A-Z]+)(\$?)(\d+)$/)
+        const clean = addr.replace(/\$/g, '')
+        const match = clean.match(/^([A-Za-z]{1,3})(\d+)$/)
         if (!match) return { row: 0, col: 0 }
-        const col = match[2].split('').reduce((acc, ch) => acc * 26 + (ch.charCodeAt(0) - 64), 0) - 1
-        const row = parseInt(match[4]) - 1
-        return { row, col }
+        const colStr = match[1].toUpperCase()
+        let col = 0
+        for (let i = 0; i < colStr.length; i++) {
+            col = col * 26 + colStr.charCodeAt(i) - 64
+        }
+        return { row: parseInt(match[2], 10) - 1, col: col - 1 }
     }
 
-    private _buildFeedback(results: CellRuleResult[], pct: number): string {
-        if (pct >= 100) return '완벽합니다! 모든 항목을 정확하게 완성했습니다.'
-        const failed = results.filter(r => !r.passed)
-        if (failed.length === 0) return '훌륭합니다!'
-        return `${failed.length}개 항목이 틀렸습니다. 다시 확인해보세요.`
+    private _parseCellVal(json: string): { t: string; v?: unknown } | null {
+        try { return JSON.parse(json) } catch { return null }
+    }
+
+    private _toValue(result: { t: string; v?: unknown } | null): CellValue {
+        if (!result) return null
+        switch (result.t) {
+            case 'n':   return typeof result.v === 'number' ? result.v : null
+            case 's':   return typeof result.v === 'string' ? result.v : null
+            case 'b':   return typeof result.v === 'boolean' ? result.v : null
+            case 'e':   return String(result.v ?? '#ERROR')
+            case 'nil': return null
+            default:    return null
+        }
+    }
+
+    private _buildCellHint(rule: CellGradingRule, actualValue: CellValue, formulaUsed?: string, formulaMatched?: boolean): string {
+        const parts: string[] = []
+        if (rule.expectedValue !== undefined && rule.expectedValue !== null) {
+            parts.push(`예상값: ${rule.expectedValue}, 실제값: ${actualValue ?? '(빈 셀)'}`)
+        }
+        if (rule.checkFormula && formulaMatched === false) {
+            parts.push(formulaUsed
+                ? `수식 패턴이 맞지 않습니다 (사용된 수식: ${formulaUsed})`
+                : '수식이 없습니다',
+            )
+        }
+        return parts.join(' / ') || '오답입니다.'
+    }
+
+    private _buildFeedback(
+        cellResults: CellRuleResult[],
+        tableResults: GradingResult['tableResults'],
+        percentage: number,
+    ): string {
+        if (percentage >= 100) return '완벽합니다! 모든 항목을 정확하게 완성했습니다.'
+        const failedCells = cellResults.filter(r => !r.passed)
+        const failedTables = tableResults.filter(r => !r.passed)
+        const total = failedCells.length + failedTables.length
+        if (total === 0) return '훌륭합니다!'
+        const parts = [`${total}개 항목이 틀렸습니다.`]
+        if (failedCells.length > 0) parts.push(`틀린 셀: ${failedCells.map(r => r.address).join(', ')}`)
+        if (failedTables.length > 0) parts.push(`표 오류: ${failedTables.map(r => r.name).join(', ')}`)
+        return parts.join(' ')
     }
 }
 

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -7,7 +7,8 @@
         "rootDir": "./src",
         "composite": true,
         "paths": {
-            "@cellix/shared": ["../shared/src/index.ts"]
+            "@cellix/shared": ["../shared/src/index.ts"],
+            "formula-engine-node": ["../formula-engine/pkg-node/formula_engine.d.ts"]
         }
     },
     "include": ["src"],

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,6 +19,7 @@
         "echarts": "^6.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^7.14.2",
         "zustand": "^5.0.12"
     },
     "devDependencies": {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,39 @@
-import { SpreadsheetShell } from "./components/SpreadsheetShell";
+import React, { useEffect } from 'react'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { AuthPage } from './pages/AuthPage'
+import { ProblemListPage } from './pages/ProblemListPage'
+import { ProblemPage } from './pages/ProblemPage'
+import { ProfilePage } from './pages/ProfilePage'
+import { useAuthStore } from './store/useAuthStore'
+
+function PrivateRoute({ children }: { children: React.ReactNode }) {
+    const { user, isLoading } = useAuthStore()
+    if (isLoading) {
+        return (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', color: '#5f6368' }}>
+                로딩 중...
+            </div>
+        )
+    }
+    return user ? <>{children}</> : <Navigate to="/login" replace />
+}
 
 export default function App() {
-    return <SpreadsheetShell />;
+    const { checkAuth } = useAuthStore()
+
+    useEffect(() => {
+        checkAuth()
+    }, [checkAuth])
+
+    return (
+        <BrowserRouter>
+            <Routes>
+                <Route path="/login" element={<AuthPage />} />
+                <Route path="/" element={<PrivateRoute><ProblemListPage /></PrivateRoute>} />
+                <Route path="/problems/:id" element={<PrivateRoute><ProblemPage /></PrivateRoute>} />
+                <Route path="/profile" element={<PrivateRoute><ProfilePage /></PrivateRoute>} />
+                <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+        </BrowserRouter>
+    )
 }

--- a/packages/frontend/src/api/client.ts
+++ b/packages/frontend/src/api/client.ts
@@ -1,0 +1,54 @@
+import type { ApiResponse } from '@cellix/shared'
+
+const BASE = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:3001'
+
+let _accessToken: string | null = sessionStorage.getItem('accessToken')
+
+async function _doFetch(method: string, path: string, body: unknown, token: string | null): Promise<Response> {
+    return fetch(`${BASE}${path}`, {
+        method,
+        headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        credentials: 'include',
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+}
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    let res = await _doFetch(method, path, body, _accessToken)
+
+    if (res.status === 401) {
+        try {
+            const refreshRes = await fetch(`${BASE}/api/auth/refresh`, {
+                method: 'POST',
+                credentials: 'include',
+            })
+            if (refreshRes.ok) {
+                const refreshData = await refreshRes.json() as ApiResponse<{ accessToken: string }>
+                apiClient.setToken(refreshData.data?.accessToken ?? null)
+                res = await _doFetch(method, path, body, _accessToken)
+            }
+        } catch {
+            apiClient.setToken(null)
+        }
+    }
+
+    const json = await res.json() as ApiResponse<T>
+    if (!json.success) throw new Error(json.error ?? 'Unknown error')
+    return json.data as T
+}
+
+export const apiClient = {
+    get<T>(path: string): Promise<T> { return request<T>('GET', path) },
+    post<T>(path: string, body?: unknown): Promise<T> { return request<T>('POST', path, body) },
+    put<T>(path: string, body?: unknown): Promise<T> { return request<T>('PUT', path, body) },
+    delete<T>(path: string): Promise<T> { return request<T>('DELETE', path) },
+    setToken(token: string | null): void {
+        _accessToken = token
+        if (token) sessionStorage.setItem('accessToken', token)
+        else sessionStorage.removeItem('accessToken')
+    },
+    getToken(): string | null { return _accessToken },
+}

--- a/packages/frontend/src/api/types.ts
+++ b/packages/frontend/src/api/types.ts
@@ -1,0 +1,63 @@
+import type { CellValue } from '@cellix/shared'
+import type { DifficultyLevel, ProblemType } from '@cellix/shared'
+
+export interface ProblemSummary {
+    id: string
+    title: string
+    description: string
+    type: ProblemType
+    difficulty: DifficultyLevel
+    score: number
+    timeLimit: number | null
+    hints: string[]
+    tags: string[]
+    isPublished: boolean
+    createdAt: string
+    updatedAt: string
+    templateWorkbook: unknown
+}
+
+export interface CellRuleResult {
+    address: string
+    sheetId: string
+    passed: boolean
+    earnedScore: number
+    maxScore: number
+    actualValue?: CellValue
+    expectedValue?: CellValue
+    formulaUsed?: string
+    formulaMatched?: boolean
+    hint?: string
+}
+
+export interface TableRuleResult {
+    name: string
+    passed: boolean
+    earnedScore: number
+    maxScore: number
+    hint?: string
+}
+
+export interface GradingResult {
+    totalScore: number
+    maxScore: number
+    percentage: number
+    status: 'pass' | 'partial' | 'fail'
+    cellResults: CellRuleResult[]
+    tableResults: TableRuleResult[]
+    feedback: string
+}
+
+export interface SubmissionResponse {
+    submission: {
+        id: string
+        userId: string
+        problemId: string
+        totalScore: string
+        maxScore: number
+        percentage: string
+        status: string
+        submittedAt: string
+    }
+    result: GradingResult
+}

--- a/packages/frontend/src/components/GridCanvas.tsx
+++ b/packages/frontend/src/components/GridCanvas.tsx
@@ -157,6 +157,7 @@ export function GridCanvas() {
             getCellBySheetRef.current = (sid: string, r: number, c: number) =>
                 useWorkbookStore.getState().getCell(sid, r, c)
             setIsEngineReady(true)
+            useWorkbookStore.getState().setEngineReady(true)
 
             // chartManager 변경 시 차트 목록 버전 업데이트
             const unsubCharts = chartManager.subscribe(() =>

--- a/packages/frontend/src/components/ResultModal.tsx
+++ b/packages/frontend/src/components/ResultModal.tsx
@@ -1,0 +1,129 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { GradingResult } from '../api/types'
+
+interface ResultModalProps {
+    result: GradingResult
+    onClose: () => void
+    onRetry: () => void
+}
+
+export function ResultModal({ result, onClose, onRetry }: ResultModalProps) {
+    const navigate = useNavigate()
+
+    const { percentage, totalScore, maxScore, status, cellResults, tableResults, feedback } = result
+
+    const radius = 54
+    const circumference = 2 * Math.PI * radius
+    const dashOffset = circumference * (1 - Math.min(percentage, 100) / 100)
+
+    const statusConfig = {
+        pass: { label: '통과', color: '#0f9d58', bg: '#e6f4ea' },
+        partial: { label: '부분 통과', color: '#f4b400', bg: '#fef9e7' },
+        fail: { label: '실패', color: '#db4437', bg: '#fce8e6' },
+    }
+    const sc = statusConfig[status]
+
+    const allResults = [
+        ...cellResults.map(r => ({ key: r.address, label: r.address, passed: r.passed, hint: r.hint, detail: r.expectedValue !== undefined ? `예상: ${r.expectedValue} / 실제: ${r.actualValue ?? '(빈 셀)'}` : undefined })),
+        ...tableResults.map(r => ({ key: `table:${r.name}`, label: `표 "${r.name}"`, passed: r.passed, hint: r.hint, detail: undefined })),
+    ]
+
+    return (
+        <div style={{
+            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            zIndex: 1000,
+        }} onClick={onClose}>
+            <div style={{
+                background: '#fff', borderRadius: 16, width: 480, maxHeight: '80vh',
+                overflow: 'hidden', display: 'flex', flexDirection: 'column',
+                boxShadow: '0 8px 32px rgba(0,0,0,0.2)',
+            }} onClick={e => e.stopPropagation()}>
+
+                {/* 헤더 */}
+                <div style={{ padding: '28px 28px 20px', textAlign: 'center', borderBottom: '1px solid #f1f3f4' }}>
+                    <svg width={128} height={128} style={{ display: 'block', margin: '0 auto 16px' }}>
+                        <circle cx={64} cy={64} r={radius} fill="none" stroke="#f1f3f4" strokeWidth={10} />
+                        <circle
+                            cx={64} cy={64} r={radius} fill="none"
+                            stroke={sc.color} strokeWidth={10}
+                            strokeDasharray={circumference}
+                            strokeDashoffset={dashOffset}
+                            strokeLinecap="round"
+                            transform="rotate(-90 64 64)"
+                            style={{ transition: 'stroke-dashoffset 0.6s ease' }}
+                        />
+                        <text x={64} y={68} textAnchor="middle" fontSize={22} fontWeight={700} fill="#202124">
+                            {Math.round(percentage)}%
+                        </text>
+                    </svg>
+
+                    <div style={{ fontSize: 20, fontWeight: 700, color: '#202124', marginBottom: 6 }}>
+                        {totalScore} / {maxScore}점
+                    </div>
+                    <span style={{
+                        display: 'inline-block', padding: '4px 12px', borderRadius: 12,
+                        fontSize: 13, fontWeight: 600, color: sc.color, background: sc.bg,
+                    }}>
+                        {sc.label}
+                    </span>
+                </div>
+
+                {/* 피드백 */}
+                <div style={{ padding: '16px 28px 8px', fontSize: 14, color: '#5f6368' }}>
+                    {feedback}
+                </div>
+
+                {/* 결과 목록 */}
+                {allResults.length > 0 && (
+                    <div style={{ padding: '0 28px 16px', overflowY: 'auto', flex: 1 }}>
+                        {allResults.map(r => (
+                            <div key={r.key} style={{
+                                display: 'flex', flexDirection: 'column', gap: 2,
+                                padding: '8px 0', borderBottom: '1px solid #f1f3f4',
+                            }}>
+                                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                                    <span style={{ fontSize: 16 }}>{r.passed ? '✅' : '❌'}</span>
+                                    <span style={{ fontSize: 13, fontWeight: 600, color: '#202124' }}>{r.label}</span>
+                                    {r.detail && (
+                                        <span style={{ fontSize: 12, color: '#5f6368', marginLeft: 'auto' }}>{r.detail}</span>
+                                    )}
+                                </div>
+                                {!r.passed && r.hint && (
+                                    <div style={{ fontSize: 12, color: '#5f6368', paddingLeft: 24 }}>
+                                        💡 {r.hint}
+                                    </div>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {/* 버튼 */}
+                <div style={{ padding: '16px 28px', display: 'flex', gap: 10, borderTop: '1px solid #f1f3f4' }}>
+                    <button
+                        onClick={onRetry}
+                        style={{
+                            flex: 1, padding: '10px 0', background: '#fff',
+                            border: '1px solid #dadce0', borderRadius: 8,
+                            fontSize: 14, fontWeight: 600, cursor: 'pointer', color: '#202124',
+                        }}
+                    >
+                        다시 풀기
+                    </button>
+                    <button
+                        onClick={() => navigate('/')}
+                        style={{
+                            flex: 1, padding: '10px 0', background: '#1a73e8',
+                            border: 'none', borderRadius: 8,
+                            fontSize: 14, fontWeight: 600, cursor: 'pointer', color: '#fff',
+                        }}
+                    >
+                        문제 목록으로
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/packages/frontend/src/components/SpreadsheetShell.tsx
+++ b/packages/frontend/src/components/SpreadsheetShell.tsx
@@ -20,16 +20,21 @@ import { SheetTabs } from './SheetTabs'
  *   │         SheetTabs          │  30px
  *   └────────────────────────────┘
  */
-export function SpreadsheetShell() {
+interface SpreadsheetShellProps {
+    style?: React.CSSProperties
+}
+
+export function SpreadsheetShell({ style }: SpreadsheetShellProps = {}) {
     return (
         <div
             style={{
                 display: 'flex',
                 flexDirection: 'column',
-                width: '100vw',
-                height: '100vh',
+                width: '100%',
+                height: '100%',
                 overflow: 'hidden',
                 background: '#f8f9fa',
+                ...style,
             }}
         >
             <Toolbar />

--- a/packages/frontend/src/pages/AuthPage.tsx
+++ b/packages/frontend/src/pages/AuthPage.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../store/useAuthStore'
+
+export function AuthPage() {
+    const [mode, setMode] = useState<'login' | 'register'>('login')
+    const [email, setEmail] = useState('')
+    const [password, setPassword] = useState('')
+    const [name, setName] = useState('')
+    const [error, setError] = useState('')
+    const [loading, setLoading] = useState(false)
+
+    const { login, register } = useAuthStore()
+    const navigate = useNavigate()
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setError('')
+        setLoading(true)
+        try {
+            if (mode === 'login') {
+                await login(email, password)
+            } else {
+                await register(email, password, name)
+            }
+            navigate('/')
+        } catch (err) {
+            setError(err instanceof Error ? err.message : '오류가 발생했습니다.')
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    const inputStyle: React.CSSProperties = {
+        width: '100%',
+        padding: '10px 12px',
+        border: '1px solid #dadce0',
+        borderRadius: 6,
+        fontSize: 14,
+        outline: 'none',
+        boxSizing: 'border-box',
+    }
+
+    const labelStyle: React.CSSProperties = {
+        display: 'block',
+        fontSize: 13,
+        color: '#5f6368',
+        marginBottom: 4,
+    }
+
+    return (
+        <div style={{
+            minHeight: '100vh',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: '#f8f9fa',
+        }}>
+            <div style={{
+                width: 400,
+                background: '#fff',
+                borderRadius: 12,
+                boxShadow: '0 2px 12px rgba(0,0,0,0.1)',
+                padding: 40,
+            }}>
+                <h1 style={{ margin: '0 0 8px', fontSize: 24, fontWeight: 700, color: '#202124' }}>
+                    Cellix
+                </h1>
+                <p style={{ margin: '0 0 28px', fontSize: 14, color: '#5f6368' }}>
+                    {mode === 'login' ? '스프레드시트 교육 플랫폼' : '계정 만들기'}
+                </p>
+
+                <form onSubmit={handleSubmit}>
+                    {mode === 'register' && (
+                        <div style={{ marginBottom: 16 }}>
+                            <label style={labelStyle}>이름</label>
+                            <input
+                                style={inputStyle}
+                                type="text"
+                                value={name}
+                                onChange={e => setName(e.target.value)}
+                                placeholder="홍길동"
+                                required
+                            />
+                        </div>
+                    )}
+                    <div style={{ marginBottom: 16 }}>
+                        <label style={labelStyle}>이메일</label>
+                        <input
+                            style={inputStyle}
+                            type="email"
+                            value={email}
+                            onChange={e => setEmail(e.target.value)}
+                            placeholder="example@email.com"
+                            required
+                        />
+                    </div>
+                    <div style={{ marginBottom: 24 }}>
+                        <label style={labelStyle}>비밀번호</label>
+                        <input
+                            style={inputStyle}
+                            type="password"
+                            value={password}
+                            onChange={e => setPassword(e.target.value)}
+                            placeholder="••••••••"
+                            required
+                            minLength={8}
+                        />
+                    </div>
+
+                    {error && (
+                        <div style={{
+                            marginBottom: 16,
+                            padding: '8px 12px',
+                            background: '#fce8e6',
+                            borderRadius: 6,
+                            color: '#c5221f',
+                            fontSize: 13,
+                        }}>
+                            {error}
+                        </div>
+                    )}
+
+                    <button
+                        type="submit"
+                        disabled={loading}
+                        style={{
+                            width: '100%',
+                            padding: '11px 0',
+                            background: loading ? '#a8c7fa' : '#1a73e8',
+                            color: '#fff',
+                            border: 'none',
+                            borderRadius: 6,
+                            fontSize: 14,
+                            fontWeight: 600,
+                            cursor: loading ? 'not-allowed' : 'pointer',
+                        }}
+                    >
+                        {loading ? '처리 중...' : (mode === 'login' ? '로그인' : '가입하기')}
+                    </button>
+                </form>
+
+                <p style={{ marginTop: 20, textAlign: 'center', fontSize: 13, color: '#5f6368' }}>
+                    {mode === 'login' ? '계정이 없으신가요? ' : '이미 계정이 있으신가요? '}
+                    <button
+                        onClick={() => { setMode(mode === 'login' ? 'register' : 'login'); setError('') }}
+                        style={{
+                            background: 'none',
+                            border: 'none',
+                            color: '#1a73e8',
+                            cursor: 'pointer',
+                            fontSize: 13,
+                            fontWeight: 600,
+                        }}
+                    >
+                        {mode === 'login' ? '회원가입' : '로그인'}
+                    </button>
+                </p>
+            </div>
+        </div>
+    )
+}

--- a/packages/frontend/src/pages/ProblemListPage.tsx
+++ b/packages/frontend/src/pages/ProblemListPage.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import { useAuthStore } from '../store/useAuthStore'
+import type { ProblemSummary } from '../api/types'
+import type { DifficultyLevel } from '@cellix/shared'
+
+const DIFFICULTY_LABEL: Record<DifficultyLevel, string> = {
+    easy: '쉬움',
+    medium: '보통',
+    hard: '어려움',
+}
+
+const DIFFICULTY_COLOR: Record<DifficultyLevel, string> = {
+    easy: '#0f9d58',
+    medium: '#f4b400',
+    hard: '#db4437',
+}
+
+export function ProblemListPage() {
+    const [problems, setProblems] = useState<ProblemSummary[]>([])
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState('')
+    const [filter, setFilter] = useState<DifficultyLevel | 'all'>('all')
+    const [search, setSearch] = useState('')
+
+    const { user, logout } = useAuthStore()
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        apiClient.get<{ problems: ProblemSummary[]; total: number }>('/api/problems?limit=50')
+            .then(data => setProblems(data.problems ?? []))
+            .catch(err => setError(err.message))
+            .finally(() => setLoading(false))
+    }, [])
+
+    const filtered = problems.filter(p => {
+        if (filter !== 'all' && p.difficulty !== filter) return false
+        if (search && !p.title.toLowerCase().includes(search.toLowerCase())) return false
+        return true
+    })
+
+    return (
+        <div style={{ minHeight: '100vh', background: '#f8f9fa' }}>
+            {/* 헤더 */}
+            <div style={{
+                background: '#fff',
+                borderBottom: '1px solid #dadce0',
+                padding: '0 24px',
+                display: 'flex',
+                alignItems: 'center',
+                height: 56,
+                gap: 16,
+            }}>
+                <span style={{ fontSize: 18, fontWeight: 700, color: '#202124' }}>Cellix</span>
+                <span style={{ flex: 1 }} />
+                <span style={{ fontSize: 14, color: '#5f6368' }}>{user?.name}</span>
+                <button
+                    onClick={() => navigate('/profile')}
+                    style={navBtnStyle}
+                >내 정보</button>
+                <button
+                    onClick={() => logout().then(() => navigate('/login'))}
+                    style={navBtnStyle}
+                >로그아웃</button>
+            </div>
+
+            <div style={{ maxWidth: 900, margin: '32px auto', padding: '0 24px' }}>
+                <h2 style={{ margin: '0 0 24px', fontSize: 22, fontWeight: 700, color: '#202124' }}>
+                    문제 목록
+                </h2>
+
+                {/* 필터 + 검색 */}
+                <div style={{ display: 'flex', gap: 8, marginBottom: 20, alignItems: 'center' }}>
+                    {(['all', 'easy', 'medium', 'hard'] as const).map(d => (
+                        <button
+                            key={d}
+                            onClick={() => setFilter(d)}
+                            style={{
+                                padding: '6px 14px',
+                                borderRadius: 20,
+                                border: '1px solid',
+                                borderColor: filter === d ? '#1a73e8' : '#dadce0',
+                                background: filter === d ? '#e8f0fe' : '#fff',
+                                color: filter === d ? '#1a73e8' : '#5f6368',
+                                fontSize: 13,
+                                cursor: 'pointer',
+                                fontWeight: filter === d ? 600 : 400,
+                            }}
+                        >
+                            {d === 'all' ? '전체' : DIFFICULTY_LABEL[d]}
+                        </button>
+                    ))}
+                    <input
+                        style={{
+                            marginLeft: 'auto',
+                            padding: '7px 12px',
+                            border: '1px solid #dadce0',
+                            borderRadius: 6,
+                            fontSize: 13,
+                            outline: 'none',
+                            width: 200,
+                        }}
+                        placeholder="제목 검색..."
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                    />
+                </div>
+
+                {loading && <div style={{ textAlign: 'center', color: '#5f6368', padding: 48 }}>로딩 중...</div>}
+                {error && <div style={{ color: '#c5221f', padding: 16 }}>{error}</div>}
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                    {filtered.map(p => (
+                        <div
+                            key={p.id}
+                            onClick={() => navigate(`/problems/${p.id}`)}
+                            style={{
+                                background: '#fff',
+                                border: '1px solid #dadce0',
+                                borderRadius: 10,
+                                padding: '16px 20px',
+                                cursor: 'pointer',
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 16,
+                                transition: 'box-shadow 0.15s',
+                            }}
+                            onMouseEnter={e => (e.currentTarget.style.boxShadow = '0 2px 8px rgba(0,0,0,0.12)')}
+                            onMouseLeave={e => (e.currentTarget.style.boxShadow = 'none')}
+                        >
+                            <div style={{ flex: 1 }}>
+                                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                                    <span style={{ fontSize: 15, fontWeight: 600, color: '#202124' }}>{p.title}</span>
+                                    <span style={{
+                                        padding: '2px 8px',
+                                        borderRadius: 10,
+                                        fontSize: 11,
+                                        fontWeight: 600,
+                                        color: DIFFICULTY_COLOR[p.difficulty],
+                                        background: `${DIFFICULTY_COLOR[p.difficulty]}18`,
+                                    }}>
+                                        {DIFFICULTY_LABEL[p.difficulty]}
+                                    </span>
+                                </div>
+                                <div style={{ fontSize: 13, color: '#5f6368', lineHeight: 1.4 }}>
+                                    {p.description.slice(0, 80)}{p.description.length > 80 ? '...' : ''}
+                                </div>
+                                {p.tags.length > 0 && (
+                                    <div style={{ marginTop: 6, display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                                        {p.tags.map(t => (
+                                            <span key={t} style={{
+                                                padding: '2px 6px',
+                                                background: '#f1f3f4',
+                                                borderRadius: 4,
+                                                fontSize: 11,
+                                                color: '#5f6368',
+                                            }}>{t}</span>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                            <div style={{ textAlign: 'right', minWidth: 80 }}>
+                                <div style={{ fontSize: 16, fontWeight: 700, color: '#1a73e8' }}>{p.score}점</div>
+                                {p.timeLimit && (
+                                    <div style={{ fontSize: 12, color: '#5f6368', marginTop: 2 }}>
+                                        {Math.floor(p.timeLimit / 60)}분
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                    {!loading && filtered.length === 0 && (
+                        <div style={{ textAlign: 'center', color: '#5f6368', padding: 48 }}>
+                            조건에 맞는 문제가 없습니다.
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const navBtnStyle: React.CSSProperties = {
+    padding: '6px 14px',
+    background: 'none',
+    border: '1px solid #dadce0',
+    borderRadius: 6,
+    fontSize: 13,
+    cursor: 'pointer',
+    color: '#5f6368',
+}

--- a/packages/frontend/src/pages/ProblemPage.tsx
+++ b/packages/frontend/src/pages/ProblemPage.tsx
@@ -1,0 +1,317 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import type { GradingResult, ProblemSummary, SubmissionResponse } from '../api/types'
+import { SpreadsheetShell } from '../components/SpreadsheetShell'
+import { ResultModal } from '../components/ResultModal'
+import { useWorkbookStore } from '../store/useWorkbookStore'
+import { useAuthStore } from '../store/useAuthStore'
+import { formulaEngine } from '../workers'
+import { serializeWorkbook, deserializeWorkbook } from '@cellix/shared'
+import type { SerializedWorkbookData } from '@cellix/shared'
+import type { CellData } from '@cellix/shared'
+
+function formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60)
+    const s = seconds % 60
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+export function ProblemPage() {
+    const { id } = useParams<{ id: string }>()
+    const navigate = useNavigate()
+
+    const [problem, setProblem] = useState<ProblemSummary | null>(null)
+    const [loadingProblem, setLoadingProblem] = useState(true)
+    const [loadError, setLoadError] = useState('')
+    const [submitting, setSubmitting] = useState(false)
+    const [gradingResult, setGradingResult] = useState<GradingResult | null>(null)
+    const [elapsed, setElapsed] = useState(0)
+
+    const engineReady = useWorkbookStore(s => s.engineReady)
+    const { logout } = useAuthStore()
+
+    const templateRef = useRef<SerializedWorkbookData | null>(null)
+    const prevSheetsRef = useRef<string[]>([])
+
+    // ── 문제 로드 ──────────────────────────────────────────────────────────────
+    useEffect(() => {
+        if (!id) return
+        setLoadingProblem(true)
+        setLoadError('')
+        setProblem(null)
+        useWorkbookStore.getState().setEngineReady(false)
+
+        apiClient.get<ProblemSummary>(`/api/problems/${id}`)
+            .then(p => {
+                const template = p.templateWorkbook as SerializedWorkbookData | null
+
+                if (template && template.sheetOrder?.length > 0) {
+                    // 템플릿으로 스토어 초기화
+                    const sheets = template.sheetOrder.map(sid => ({
+                        id: sid,
+                        name: template.sheets[sid]?.name ?? sid,
+                    }))
+                    const cells: Record<string, CellData> = {}
+                    for (const sid of template.sheetOrder) {
+                        const sheetCells = template.sheets[sid]?.cells ?? {}
+                        for (const [cellKey, cellData] of Object.entries(sheetCells)) {
+                            cells[`${sid}:${cellKey}`] = cellData as CellData
+                        }
+                    }
+                    useWorkbookStore.setState({
+                        sheets,
+                        activeSheetId: template.activeSheetId ?? template.sheetOrder[0],
+                        cells,
+                        calculatedValues: {},
+                        engineReady: false,
+                    })
+                    templateRef.current = template
+                } else {
+                    templateRef.current = null
+                }
+
+                setProblem(p)
+                setLoadingProblem(false)
+            })
+            .catch(err => {
+                setLoadError(err.message)
+                setLoadingProblem(false)
+            })
+    }, [id])
+
+    // ── 엔진 준비 후 템플릿 셀 로드 ──────────────────────────────────────────
+    useEffect(() => {
+        if (!problem || !engineReady) return
+        const template = templateRef.current
+        if (!template) return
+
+        const sheetOrder = template.sheetOrder ?? []
+
+        // 이전 문제의 시트 제거 (first sheet은 GridCanvas가 이미 engine에 add함)
+        for (const oldSid of prevSheetsRef.current) {
+            if (!sheetOrder.includes(oldSid)) {
+                formulaEngine.removeSheet(oldSid).catch(() => {})
+            }
+        }
+        prevSheetsRef.current = sheetOrder
+
+        // 첫 시트: GridCanvas가 add_sheet 완료 → loadSheet만 실행
+        const firstId = sheetOrder[0]
+        if (firstId) {
+            const sheetCells = template.sheets[firstId]?.cells ?? {}
+            const cells = Object.entries(sheetCells).map(([key, cellData]) => {
+                const [r, c] = key.split(':')
+                return { row: parseInt(r, 10), col: parseInt(c, 10), value: (cellData as CellData).value, formula: (cellData as CellData).formula }
+            })
+            formulaEngine.loadSheet(firstId, cells).catch(console.error)
+        }
+
+        // 나머지 시트: addSheet + loadSheet
+        for (let i = 1; i < sheetOrder.length; i++) {
+            const sid = sheetOrder[i]
+            const sheetMeta = template.sheets[sid]
+            if (!sheetMeta) continue
+            formulaEngine.addSheet(sid, sheetMeta.name)
+                .then(() => {
+                    const sheetCells = sheetMeta.cells ?? {}
+                    const cells = Object.entries(sheetCells).map(([key, cellData]) => {
+                        const [r, c] = key.split(':')
+                        return { row: parseInt(r, 10), col: parseInt(c, 10), value: (cellData as CellData).value, formula: (cellData as CellData).formula }
+                    })
+                    return formulaEngine.loadSheet(sid, cells)
+                })
+                .catch(console.error)
+        }
+    }, [problem, engineReady])
+
+    // ── 타이머 ────────────────────────────────────────────────────────────────
+    useEffect(() => {
+        if (!problem) return
+        setElapsed(0)
+        const interval = setInterval(() => setElapsed(e => e + 1), 1000)
+        return () => clearInterval(interval)
+    }, [problem])
+
+    // ── 초기화 ────────────────────────────────────────────────────────────────
+    const handleReset = () => {
+        const template = templateRef.current
+        if (!template) return
+        const cells: Record<string, CellData> = {}
+        for (const sid of template.sheetOrder ?? []) {
+            const sheetCells = template.sheets[sid]?.cells ?? {}
+            for (const [cellKey, cellData] of Object.entries(sheetCells)) {
+                cells[`${sid}:${cellKey}`] = cellData as CellData
+            }
+        }
+        useWorkbookStore.setState({ cells, calculatedValues: {} })
+        setGradingResult(null)
+        setElapsed(0)
+    }
+
+    // ── 제출 ─────────────────────────────────────────────────────────────────
+    const handleSubmit = async () => {
+        if (!problem || submitting) return
+        setSubmitting(true)
+        try {
+            const { sheets, activeSheetId, cells } = useWorkbookStore.getState()
+            const serializedSheets: Record<string, { id: string; name: string; cells: Record<string, CellData>; columnMeta: Record<string, unknown>; rowMeta: Record<string, unknown> }> = {}
+            for (const sheet of sheets) {
+                const prefix = `${sheet.id}:`
+                const sheetCells: Record<string, CellData> = {}
+                for (const [key, data] of Object.entries(cells)) {
+                    if (key.startsWith(prefix)) {
+                        sheetCells[key.slice(prefix.length)] = data
+                    }
+                }
+                serializedSheets[sheet.id] = {
+                    id: sheet.id,
+                    name: sheet.name,
+                    cells: sheetCells,
+                    columnMeta: {},
+                    rowMeta: {},
+                }
+            }
+            const workbookData: SerializedWorkbookData = {
+                id: problem.id,
+                name: problem.title,
+                sheets: serializedSheets as SerializedWorkbookData['sheets'],
+                sheetOrder: sheets.map(s => s.id),
+                activeSheetId,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            }
+
+            const data = await apiClient.post<SubmissionResponse>('/api/submissions', {
+                problemId: problem.id,
+                workbookData,
+                timeSpentSeconds: elapsed,
+            })
+            setGradingResult(data.result)
+        } catch (err) {
+            console.error('제출 실패:', err)
+            alert(err instanceof Error ? err.message : '제출 중 오류가 발생했습니다.')
+        } finally {
+            setSubmitting(false)
+        }
+    }
+
+    const timeLimit = problem?.timeLimit ?? null
+    const timerDisplay = timeLimit
+        ? formatTime(Math.max(0, timeLimit - elapsed))
+        : formatTime(elapsed)
+    const timerOver = timeLimit !== null && elapsed >= timeLimit
+
+    if (loadingProblem) {
+        return (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', color: '#5f6368', fontSize: 15 }}>
+                문제 불러오는 중...
+            </div>
+        )
+    }
+
+    if (loadError) {
+        return (
+            <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100vh', gap: 12 }}>
+                <div style={{ color: '#c5221f' }}>{loadError}</div>
+                <button onClick={() => navigate('/')} style={btnStyle('#1a73e8')}>문제 목록으로</button>
+            </div>
+        )
+    }
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
+            {/* ── 헤더 ── */}
+            <div style={{
+                display: 'flex', alignItems: 'center', gap: 12, padding: '0 16px',
+                height: 48, background: '#fff', borderBottom: '1px solid #dadce0',
+                flexShrink: 0,
+            }}>
+                <button
+                    onClick={() => navigate('/')}
+                    style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 13, color: '#5f6368', padding: '4px 8px' }}
+                >
+                    ← 목록
+                </button>
+                <span style={{ fontSize: 14, fontWeight: 600, color: '#202124', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {problem?.title}
+                </span>
+                <span style={{
+                    fontSize: 14, fontWeight: 700, fontVariantNumeric: 'tabular-nums',
+                    color: timerOver ? '#c5221f' : '#202124',
+                    minWidth: 56, textAlign: 'center',
+                }}>
+                    {timerDisplay}
+                </span>
+                <button onClick={handleReset} style={btnStyle('#5f6368')}>초기화</button>
+                <button
+                    onClick={handleSubmit}
+                    disabled={submitting}
+                    style={btnStyle(submitting ? '#a8c7fa' : '#1a73e8')}
+                >
+                    {submitting ? '채점 중...' : '제출'}
+                </button>
+            </div>
+
+            {/* ── 본문 ── */}
+            <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+                {/* 문제 설명 패널 */}
+                <div style={{
+                    width: 300, flexShrink: 0, borderRight: '1px solid #dadce0',
+                    overflowY: 'auto', padding: 20, background: '#fff',
+                }}>
+                    <div style={{ fontSize: 13, color: '#5f6368', marginBottom: 12, display: 'flex', gap: 6 }}>
+                        <span style={{ padding: '2px 8px', borderRadius: 10, background: '#e8f0fe', color: '#1a73e8', fontWeight: 600 }}>
+                            {problem?.score}점
+                        </span>
+                        {problem?.timeLimit && (
+                            <span style={{ padding: '2px 8px', borderRadius: 10, background: '#f1f3f4', color: '#5f6368' }}>
+                                {Math.floor(problem.timeLimit / 60)}분
+                            </span>
+                        )}
+                    </div>
+                    <div style={{ fontSize: 14, lineHeight: 1.7, color: '#202124', whiteSpace: 'pre-wrap' }}>
+                        {problem?.description}
+                    </div>
+                    {problem?.hints && problem.hints.length > 0 && (
+                        <div style={{ marginTop: 20 }}>
+                            <div style={{ fontSize: 12, fontWeight: 600, color: '#f4b400', marginBottom: 8 }}>💡 힌트</div>
+                            {problem.hints.map((h, i) => (
+                                <div key={i} style={{ fontSize: 13, color: '#5f6368', marginBottom: 6, paddingLeft: 8, borderLeft: '2px solid #f4b400' }}>
+                                    {h}
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                {/* 스프레드시트 영역 */}
+                <div style={{ flex: 1, overflow: 'hidden' }}>
+                    <SpreadsheetShell />
+                </div>
+            </div>
+
+            {/* ── 채점 결과 모달 ── */}
+            {gradingResult && (
+                <ResultModal
+                    result={gradingResult}
+                    onClose={() => setGradingResult(null)}
+                    onRetry={() => { setGradingResult(null); handleReset() }}
+                />
+            )}
+        </div>
+    )
+}
+
+function btnStyle(bg: string): React.CSSProperties {
+    return {
+        padding: '6px 14px',
+        background: bg,
+        border: 'none',
+        borderRadius: 6,
+        color: '#fff',
+        fontSize: 13,
+        fontWeight: 600,
+        cursor: 'pointer',
+    }
+}

--- a/packages/frontend/src/pages/ProfilePage.tsx
+++ b/packages/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { apiClient } from '../api/client'
+import { useAuthStore } from '../store/useAuthStore'
+
+interface Submission {
+    id: string
+    problemId: string
+    totalScore: string
+    maxScore: number
+    percentage: string
+    status: string
+    submittedAt: string
+}
+
+export function ProfilePage() {
+    const [submissions, setSubmissions] = useState<Submission[]>([])
+    const [loading, setLoading] = useState(true)
+
+    const { user, logout } = useAuthStore()
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        apiClient.get<Submission[]>('/api/submissions/me')
+            .then(data => setSubmissions(Array.isArray(data) ? data : []))
+            .catch(console.error)
+            .finally(() => setLoading(false))
+    }, [])
+
+    const handleLogout = async () => {
+        await logout()
+        navigate('/login')
+    }
+
+    const statusLabel = (s: string) =>
+        s === 'graded' ? '채점 완료' : s === 'error' ? '오류' : s
+
+    return (
+        <div style={{ minHeight: '100vh', background: '#f8f9fa' }}>
+            <div style={{
+                background: '#fff', borderBottom: '1px solid #dadce0',
+                padding: '0 24px', display: 'flex', alignItems: 'center', height: 56, gap: 12,
+            }}>
+                <button onClick={() => navigate('/')} style={navBtn}>← 문제 목록</button>
+                <span style={{ flex: 1, fontSize: 16, fontWeight: 600, color: '#202124' }}>내 정보</span>
+                <button onClick={handleLogout} style={navBtn}>로그아웃</button>
+            </div>
+
+            <div style={{ maxWidth: 720, margin: '32px auto', padding: '0 24px' }}>
+                <div style={{
+                    background: '#fff', borderRadius: 12, border: '1px solid #dadce0',
+                    padding: 24, marginBottom: 24,
+                }}>
+                    <div style={{ fontSize: 18, fontWeight: 700, color: '#202124', marginBottom: 8 }}>{user?.name}</div>
+                    <div style={{ fontSize: 14, color: '#5f6368' }}>{user?.email}</div>
+                    {user?.role === 'admin' && (
+                        <span style={{ marginTop: 8, display: 'inline-block', padding: '2px 10px', background: '#e8f0fe', color: '#1a73e8', borderRadius: 10, fontSize: 12, fontWeight: 600 }}>
+                            관리자
+                        </span>
+                    )}
+                </div>
+
+                <div style={{ fontSize: 16, fontWeight: 700, color: '#202124', marginBottom: 12 }}>제출 내역</div>
+
+                {loading && <div style={{ color: '#5f6368', textAlign: 'center', padding: 32 }}>로딩 중...</div>}
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {submissions.map(sub => (
+                        <div key={sub.id} style={{
+                            background: '#fff', border: '1px solid #dadce0',
+                            borderRadius: 8, padding: '12px 16px',
+                            display: 'flex', alignItems: 'center', gap: 12,
+                        }}>
+                            <div style={{ flex: 1 }}>
+                                <div style={{ fontSize: 13, color: '#5f6368' }}>
+                                    {new Date(sub.submittedAt).toLocaleString('ko-KR')}
+                                </div>
+                                <div style={{ fontSize: 12, color: '#9aa0a6', marginTop: 2 }}>
+                                    {statusLabel(sub.status)}
+                                </div>
+                            </div>
+                            <div style={{ textAlign: 'right' }}>
+                                <div style={{ fontSize: 16, fontWeight: 700, color: '#1a73e8' }}>
+                                    {sub.totalScore} / {sub.maxScore}점
+                                </div>
+                                <div style={{ fontSize: 12, color: '#5f6368' }}>
+                                    {parseFloat(sub.percentage).toFixed(1)}%
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                    {!loading && submissions.length === 0 && (
+                        <div style={{ textAlign: 'center', color: '#5f6368', padding: 40 }}>
+                            아직 제출 내역이 없습니다.
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const navBtn: React.CSSProperties = {
+    padding: '6px 12px', background: 'none',
+    border: '1px solid #dadce0', borderRadius: 6,
+    fontSize: 13, cursor: 'pointer', color: '#5f6368',
+}

--- a/packages/frontend/src/store/useAuthStore.ts
+++ b/packages/frontend/src/store/useAuthStore.ts
@@ -1,0 +1,65 @@
+import { create } from 'zustand'
+import { apiClient } from '../api/client'
+
+interface User {
+    id: string
+    email: string
+    name: string
+    role: string
+}
+
+interface AuthState {
+    user: User | null
+    isLoading: boolean
+    login: (email: string, password: string) => Promise<void>
+    register: (email: string, password: string, name: string) => Promise<void>
+    logout: () => Promise<void>
+    checkAuth: () => Promise<void>
+}
+
+export const useAuthStore = create<AuthState>()((set) => ({
+    user: null,
+    isLoading: true,
+
+    login: async (email, password) => {
+        const data = await apiClient.post<{ accessToken: string; user: User }>(
+            '/api/auth/login',
+            { email, password },
+        )
+        apiClient.setToken(data.accessToken)
+        set({ user: data.user })
+    },
+
+    register: async (email, password, name) => {
+        const data = await apiClient.post<{ accessToken: string; user: User }>(
+            '/api/auth/register',
+            { email, password, name },
+        )
+        apiClient.setToken(data.accessToken)
+        set({ user: data.user })
+    },
+
+    logout: async () => {
+        try {
+            await apiClient.post('/api/auth/logout')
+        } catch {
+            // ignore
+        }
+        apiClient.setToken(null)
+        set({ user: null })
+    },
+
+    checkAuth: async () => {
+        set({ isLoading: true })
+        try {
+            const data = await apiClient.post<{ accessToken: string; user: User }>(
+                '/api/auth/refresh',
+            )
+            apiClient.setToken(data.accessToken)
+            set({ user: data.user, isLoading: false })
+        } catch {
+            apiClient.setToken(null)
+            set({ user: null, isLoading: false })
+        }
+    },
+}))

--- a/packages/frontend/src/store/useWorkbookStore.ts
+++ b/packages/frontend/src/store/useWorkbookStore.ts
@@ -14,6 +14,8 @@ interface WorkbookState {
     cells: Record<string, CellData>
     /** WASM에서 받은 계산 결과 캐시. key: `${sheetId}:${row}:${col}` */
     calculatedValues: Record<string, string | number | boolean | null>
+    /** GridCanvas의 formulaEngine 초기화 완료 여부 */
+    engineReady: boolean
 
     addSheet: () => void
     deleteSheet: (id: string) => void
@@ -22,6 +24,7 @@ interface WorkbookState {
     setCell: (sheetId: string, row: number, col: number, data: CellData | null) => void
     getCell: (sheetId: string, row: number, col: number) => CellData | null
     setCalculatedValues: (values: Record<string, string | number | boolean | null>) => void
+    setEngineReady: (ready: boolean) => void
 }
 
 let _counter = 1
@@ -42,6 +45,7 @@ export const useWorkbookStore = create<WorkbookState>()((set, get) => {
         activeSheetId: firstId,
         cells: {},
         calculatedValues: {},
+        engineReady: false,
 
         addSheet: () => {
             const id = mkId()
@@ -92,5 +96,6 @@ export const useWorkbookStore = create<WorkbookState>()((set, get) => {
             get().cells[cellKey(sheetId, row, col)] ?? null,
 
         setCalculatedValues: (values) => set({ calculatedValues: values }),
+        setEngineReady: (ready) => set({ engineReady: ready }),
     }
 })

--- a/packages/frontend/src/vite-env.d.ts
+++ b/packages/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/shared/src/utils/workbook-serializer.ts
+++ b/packages/shared/src/utils/workbook-serializer.ts
@@ -51,9 +51,10 @@ export function serializeWorkbook(workbook: WorkbookData): SerializedWorkbookDat
     }
 }
 
-export function deserializeWorkbook(data: SerializedWorkbookData): WorkbookData {
+export function deserializeWorkbook(raw: unknown): WorkbookData {
+    const data = raw as SerializedWorkbookData
     const sheets = new Map<string, SheetData>()
-    for (const [sheetId, sheet] of Object.entries(data.sheets)) {
+    for (const [sheetId, sheet] of Object.entries(data.sheets ?? {})) {
         sheets.set(sheetId, {
             id: sheet.id,
             name: sheet.name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       fastify-plugin:
         specifier: ^5.1.0
         version: 5.1.0
+      formula-engine-node:
+        specifier: workspace:*
+        version: link:../formula-engine/pkg-node
       hyperformula:
         specifier: ^3.2.0
         version: 3.2.0
@@ -74,6 +77,8 @@ importers:
         version: 5.9.3
 
   packages/formula-engine/pkg: {}
+
+  packages/formula-engine/pkg-node: {}
 
   packages/frontend:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       fastify-plugin:
         specifier: ^5.1.0
         version: 5.1.0
+      hyperformula:
+        specifier: ^3.2.0
+        version: 3.2.0
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
@@ -1227,6 +1230,9 @@ packages:
     resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
     engines: {node: '>=0.8'}
 
+  chevrotain@6.5.0:
+    resolution: {integrity: sha512-BwqQ/AgmKJ8jcMEjaSnfMybnKMgGTrtDKowfTP3pX4jwVy0kNjRsT/AP6h+wC3+3NC+X8X15VWBnTCQlX+wQFg==}
+
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
@@ -1485,6 +1491,9 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
+  hyperformula@3.2.0:
+    resolution: {integrity: sha512-2vzQKKVMDPLsubZJb0JJWT/DhrkgIjsWj40Z9BIUVT6Jkl/YM5VtkLOP3agCieqW9HuqnXlWc+Vi+7XzQuC1Nw==}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1645,6 +1654,9 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  regexp-to-ast@0.4.0:
+    resolution: {integrity: sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1744,6 +1756,9 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  tiny-emitter@2.1.0:
+    resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
 
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
@@ -2629,6 +2644,10 @@ snapshots:
       adler-32: 1.3.1
       crc-32: 1.2.2
 
+  chevrotain@6.5.0:
+    dependencies:
+      regexp-to-ast: 0.4.0
+
   cluster-key-slot@1.1.2: {}
 
   codepage@1.15.0: {}
@@ -2888,6 +2907,11 @@ snapshots:
 
   help-me@5.0.0: {}
 
+  hyperformula@3.2.0:
+    dependencies:
+      chevrotain: 6.5.0
+      tiny-emitter: 2.1.0
+
   inherits@2.0.4: {}
 
   ioredis@5.10.1:
@@ -3054,6 +3078,8 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  regexp-to-ast@0.4.0: {}
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -3159,6 +3185,8 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
+
+  tiny-emitter@2.1.0: {}
 
   toad-cache@3.7.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^7.14.2
+        version: 7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@18.3.28)(react@18.3.1)
@@ -1643,6 +1646,23 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.14.2:
+    resolution: {integrity: sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.14.2:
+    resolution: {integrity: sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -3070,6 +3090,20 @@ snapshots:
       scheduler: 0.23.2
 
   react-refresh@0.17.0: {}
+
+  react-router-dom@7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-router@7.14.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.1.1
+      react: 18.3.1
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "packages/*"
   - "packages/formula-engine/pkg"
+  - "packages/formula-engine/pkg-node"


### PR DESCRIPTION
## Summary

- **Phase 8-1**: HyperFormula 기반 채점 서비스 초기 구현 (`grading.service.ts`, `submissions.routes.ts`)
- **Phase 8-0 (improve)**: formula-engine Rust WASM Node.js 타겟(`pkg-node`) 빌드 설정 및 워크스페이스 등록
- **Phase 8-1 (improve)**: HyperFormula → Rust WASM 채점 엔진 교체 — `createRequire` CJS 인터롭, `batch_set`으로 워크북 로드, `get_cell_value`/`get_cell_formula`로 채점
- **Phase 8-2**: 프론트엔드 문제 풀이 UI 전체 구현

## 주요 변경사항

### 백엔드
- `grading.service.ts`: Rust WASM `FormulaEngine`(Node.js 타겟) 사용, 프론트와 동일한 엔진으로 채점 일관성 보장
- `submissions.routes.ts`: POST `/api/submissions` — 제출 + 즉시 채점 + userProgress upsert
- `workbook-serializer.ts`: `deserializeWorkbook` 입력 타입 `unknown`으로 완화

### 프론트엔드
- `api/client.ts`: fetch 기반 API 클라이언트 (401 자동 토큰 갱신)
- `store/useAuthStore.ts`: 로그인/회원가입/로그아웃/checkAuth
- `pages/AuthPage.tsx`: 로그인·회원가입 토글 폼
- `pages/ProblemListPage.tsx`: 난이도 필터 + 검색 + 카드 목록
- `pages/ProblemPage.tsx`: 문제 풀이 (템플릿 로드 → WASM 엔진 동기화 → 타이머 → 제출)
- `pages/ProfilePage.tsx`: 내 정보 + 제출 내역
- `components/ResultModal.tsx`: SVG 원형 게이지 + 셀별/표별 채점 결과

## Test plan

- [ ] `docker compose up -d postgres redis` 후 백엔드 기동 확인
- [ ] `POST /api/auth/register` → 회원가입, `POST /api/auth/login` → accessToken 반환
- [ ] 브라우저 `/` 접속 → 로그인 페이지 리다이렉트
- [ ] 로그인 후 문제 목록 페이지 표시
- [ ] 문제 클릭 → 스프레드시트 표시, 템플릿 셀 로드
- [ ] 값 입력 후 제출 → 채점 결과 모달 표시
- [ ] `pnpm typecheck` 전 패키지 에러 없음